### PR TITLE
Removing erroneous CH1 features

### DIFF
--- a/modules/ROOT/pages/ch2-comparison.adoc
+++ b/modules/ROOT/pages/ch2-comparison.adoc
@@ -43,12 +43,9 @@ CloudHub 2.0 infrastructure behavior deviates from CloudHub 1.0 in the following
 
 CloudHub 2.0 does not support the following infrastructure features or functions that CloudHub 1.0 supports:
 
-* Anypoint Security
-* Secrets Manager
-* Tokenizer
-* Web application firewall (WAF) policies
 * xref:runtime-manager::deploying-to-cloudhub#copy-an-application-from-sandbox-to-production.adoc[Get From Sandbox functionality]
 * Insights. Use xref:monitoring::index.adoc[Anypoint Monitoring] instead.
+
 
 === Application Considerations
 


### PR DESCRIPTION
CloudHub 1.0 never supported these features, so they shouldn't be mentioned as something that support was dropped for in CloudHub 2.0:
* Anypoint Security
* Secrets Manager
* Tokenizer
* Web application firewall (WAF) policies

Those were actually supported on the Runtime Fabric VM/BM/Appliance.