### PR TITLE
W-13663437-update shard for shared space

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
@@ -156,15 +156,15 @@ For example, if you deploy an application named `myapp` to Canada (Central), the
 
 CloudHub 2.0 backend services determine the values of:
 
-_uniq-id_::
+`uniq-id`::
 A 6-digit value appended to the app name to ensure uniqueness.
-_shard_::
+`shard`::
 A 6-digit value associated with the private space that the app is deployed to.
 +
 A 6-digit value followed by hyphen (`-`) and number, associated with the shared space that the app is deployed to.
 +
-CloudHub 2.0 assigns each private space a value for _shard_.
-For apps deployed to shared spaces, each region might have multiple _shard_ values. When an app is stopped or restarted, the shard value does not change. However, when an app is deleted and redeployed in a shared space, the shard value might change.
+CloudHub 2.0 assigns each private space a value for `shard`.
+For apps deployed to shared spaces, each region might have multiple `shard` values. When an app is stopped or restarted, the `shard` value does not change. However, when an app is deleted and redeployed in a shared space, the `shard` value might change.
 
 DNS records are unique to each control plane.
 Although the EU control plane supports some of the same regions that the

--- a/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
@@ -157,11 +157,11 @@ For example, if you deploy an application named `myapp` to Canada (Central), the
 CloudHub 2.0 backend services determine the values of:
 
 `uniq-id`::
-A 6-digit value appended to the app name to ensure uniqueness.
+A 6-digit value appended to the app name to ensure uniqueness, such as `a9cdqr`.
 `shard`::
-A 6-digit value associated with the private space that the app is deployed to.
+A 6-digit value associated with the private space that the app is deployed to, such as `q9opcf`.
 +
-A 6-digit value followed by hyphen (`-`) and number, associated with the shared space that the app is deployed to.
+A 6-digit value followed by hyphen (`-`) and number, associated with the shared space that the app is deployed to, such as `bsb3v6-2`.
 +
 CloudHub 2.0 assigns each private space a value for `shard`.
 For apps deployed to shared spaces, each region might have multiple `shard` values. When an app is stopped or restarted, the `shard` value does not change. However, when an app is deleted and redeployed in a shared space, the `shard` value might change.

--- a/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
@@ -159,7 +159,9 @@ CloudHub 2.0 backend services determine the values of:
 _uniq-id_::
 A 6-digit value appended to the app name to ensure uniqueness.
 _shard_::
-A 6-digit value associated with the space (private or shared) that the app is deployed to.
+A 6-digit value associated with the private space that the app is deployed to.
++
+A 6-digit value followed by hyphen (`-`) and number, associated with the shared space that the app is deployed to.
 +
 CloudHub 2.0 assigns each private space a value for _shard_.
 For apps deployed to shared spaces, each region might have multiple _shard_ values.

--- a/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
@@ -164,7 +164,7 @@ A 6-digit value associated with the private space that the app is deployed to.
 A 6-digit value followed by hyphen (`-`) and number, associated with the shared space that the app is deployed to.
 +
 CloudHub 2.0 assigns each private space a value for _shard_.
-For apps deployed to shared spaces, each region might have multiple _shard_ values.
+For apps deployed to shared spaces, each region might have multiple _shard_ values. When an app is stopped or restarted, the shard value does not change. However, when an app is deleted and redeployed in a shared space, the shard value might change.
 
 DNS records are unique to each control plane.
 Although the EU control plane supports some of the same regions that the


### PR DESCRIPTION
GUS Issue: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001UoFZcYAN/view

Child Work Item for Pending work: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001VkuYaYAJ/view

Public Endpoint doc: https://docs.google.com/document/d/1ai26nY_iLPbnAeG59Xysoh67tLsSJ2GSuEee63nZq5s/edit#heading=h.4d8b486jj22v

Ch2 official architecture public doc: https://docs.mulesoft.com/cloudhub-2/ch2-architecture#regions-and-dns-records

Changes done:

1. Update doc for `shard` value of a Shared Space.