### PR TITLE
[W-13976741] Document CIDR conflicts

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/_partials/create-config.adoc
+++ b/cloudhub-2/modules/ROOT/pages/_partials/create-config.adoc
@@ -39,6 +39,10 @@ You cannot use the following reserved CIDR blocks:
 169.254.0.0/16
 127.0.0.0/8
 0.0.0.0/8
+100.64.0.0/16
+100.66.0.0/16
+100.67.0.0/16
+100.68.0.0/16
 ----
 
 // end::cidrBlock[]

--- a/cloudhub-2/modules/ROOT/pages/ps-create-configure-vpn.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ps-create-configure-vpn.adoc
@@ -49,6 +49,10 @@ include::partial$caveats.adoc[tag=localAsnNote]
 .. In the *Static Routes* field, specify the (comma-separated) xref:ps-gather-setup-info.adoc#static-ip-prefixes[static IP prefixes] in CIDR notation.
 +
 Click *Show Existing Routes for this Network* to view the existing routes for the private network.
++
+[NOTE]
+You cannot use/have an overlap with the following xref:ps-gather-setup-info.adoc#cidr-block[reserved CIDR blocks] for static routes
+
 // +
 // <screenshot>
 . If you want to customize the tunnel configuration, expand *Advanced Options*:


### PR DESCRIPTION
**GUS story**

[W-13976741](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001YnMxsYAF/view)


**Why?**

To avoid on-prem CIDR conflict with reserved Mulesoft CIDRs. The following has been added
100.64.0.0/16
100.66.0.0/16
100.67.0.0/16
100.68.0.0/16

<img width="744" alt="Screenshot 2023-09-13 at 9 36 06 AM" src="https://github.com/mulesoft/docs-hosting/assets/106621199/764445c3-b43a-4da6-9fdd-d332245f4ad7">


<img width="687" alt="Screenshot 2023-09-13 at 2 34 18 PM" src="https://github.com/mulesoft/docs-hosting/assets/106621199/e700c512-0026-4035-9d34-bfd5fa935876">

