### PR TITLE
W-16163209-Add guidance to not use the wildcard domain for CNAME records

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ps-config-domains.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ps-config-domains.adoc
@@ -89,7 +89,7 @@ To enable traffic to reach the apps deployed to the private space using a custom
 .. Log in to your domain registrar.
 +
 Use https://www.whois.com/[Whois^] to look up your registrar.
-.. Create a CNAME record in your vanity domain, pointing to your private space FQDN.
+.. Create a CNAME record in your vanity domain, pointing to your non-wildcard private space FQDN.
 +
 Your registrar might take up to 24 hours to apply the change.
 


### PR DESCRIPTION
Related to a recent customer case and investigation, using a CNAME record to point to a wildcard domain seems to cause issues reaching certain domains. As a result, we want to advise customers to use the FQDN for the private space that doesn't begin with a wildcard asterisk.