### PR TITLE
HPA scales _capacity_, not _workload_

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-clustering.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-clustering.adoc
@@ -47,7 +47,7 @@ If the entire application is updated or redeploying while the batch is running, 
 The main solution for persistent batch jobs in CloudHub 2.0 is to use 
 xref:object-store::index.adoc[].
 
-In Kubernetes, a Horizontal Pod Autoscaler (HPA) automatically updates a workload resource to scale the workload to match demand. Horizontal scaling automatically deploys more pods as a response to an increased load. As a result of these regular autoscaling operations, an application can be changed to a new replica without user action.
+In Kubernetes, a Horizontal Pod Autoscaler (HPA) automatically updates a workload resource to scale capacity to match demand. Horizontal scaling automatically deploys more pods as a response to an increased load. As a result of these regular autoscaling operations, an application can be changed to a new replica without user action.
 
 == Enable Clustering Features
 


### PR DESCRIPTION
HPA scales _capacity_, not _workload_.  I recognize that this language was taken directly from the Kubernetes HPA documentation, and have submitted a corresponding pull request there as well. (https://github.com/kubernetes/website/pull/53923)