### PR TITLE
W-21304753-hybrid-scheduler-note-kt

### DIFF
--- a/hybrid-standalone/modules/ROOT/pages/managing-schedulers-hybrid.adoc
+++ b/hybrid-standalone/modules/ROOT/pages/managing-schedulers-hybrid.adoc
@@ -128,6 +128,8 @@ Finalize scheduler configuration modifications:
 [IMPORTANT]
 Configuration changes apply immediately for management operations (enable/disable) but take effect on the next execution cycle for scheduling modifications (frequency, cron patterns).
 
+[NOTE]
+By default, schedules run at the frequency defined in the application. When you change the frequency of a schedule from Runtime Manager, the schedule runs at the frequency configured in Runtime Manager even if you update and redeploy the same schedule in the application JAR file.
 
 == See Also
 


### PR DESCRIPTION
Clarify that when frequency is changed in Runtime Manager, the schedule runs at that configured frequency even after redeploying the same schedule from the application JAR.