### PR TITLE
W-21616275-ch2-private-link-kt

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-view-diag.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-view-diag.adoc
@@ -9,6 +9,7 @@ Before running the MuleSoft diagnostics agent:
 include::partial$diagnostics-agent.adoc[tag=prerequisites]
 
 
+[[run-diagnostics-agent]]
 == Run the MuleSoft Diagnostics Agent
 
 . From Anypoint Platform, select *Runtime Manager* > *Applications*.

--- a/cloudhub-2/modules/ROOT/pages/ps-outbound-private-link.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ps-outbound-private-link.adoc
@@ -413,7 +413,7 @@ To configure high availability, set up the Private Link connection with at least
 == Limitations
 
 * Outbound connections have a contractual limit of 56.48 GB of data transferred per root organization per hour.
-* This configuration supports interface endpoints only.
+* This configuration supports https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints.html#vpce-interface[interface VPC endpoints] only (PrivateLink to AWS services or to a https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html[VPC endpoint service], for example a service you expose behind a load balancer). It does not support https://docs.aws.amazon.com/vpc/latest/privatelink/use-resource-endpoint.html[resource VPC endpoints] (the *Resources* endpoint type that uses resource configurations instead of a service name).
 * This configuration doesn't support CloudHub VPCs.
 * This configuration doesn't support CloudHub 2.0 private spaces that are xref:cloudhub::vpc-upgrade.adoc[upgraded from CloudHub VPCs].
 * Network connections are subject to these limits:


### PR DESCRIPTION
- Expand limitations with AWS docs links; explicit non-support for resource VPC endpoints
- Add [[run-diagnostics-agent]] anchor for cross-references
