### PR TITLE
W-21666848-hyperforce-agent-visualizer-kt

### DIFF
--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -37,7 +37,7 @@ This table indicates the support status of Anypoint Platform features on Hyperfo
 | Business Groups | Planned | Planned | Available | Available
 | External Identity Management Integration | Planned | Planned | Available | Available
 
-.2+| Agent Visualizer| All other features | Planned | Planned | Planned | Planned .2+| n/a
+.2+| xref:agent-visualizer::index.adoc[Agent Visualizer]| All other features | Planned | Planned | Planned | Planned .2+| n/a
 | Links to logs and traces | Planned | Planned | Planned | Planned
 
 .5+|xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager]| All other features     |  Planned |Planned | Available | Available .5+|  For details, refer to xref:api-manager::latest-overview-concept.adoc#APIM-hyperforce[API Manager Features by Control Plane],  xref:api-manager::analytics-landing-page.adoc[Mule API Analytics], and xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]


### PR DESCRIPTION
Make the Agent Visualizer row in the Hyperforce feature support table navigable by linking it to the Agent Visualizer documentation page.

