### PR TITLE
W-21614062: Remove deprecated IBM JVM configuration section-kt

### DIFF
--- a/hybrid-standalone/modules/ROOT/pages/creating-servers.adoc
+++ b/hybrid-standalone/modules/ROOT/pages/creating-servers.adoc
@@ -63,20 +63,6 @@ After the script completes successfully, the name of your server appears on the 
 
 If the server was running when you ran the `amc_setup` script, restart the server to reconnect with Runtime Manager.
 
-[[configure-ibm-jvm]]
-== Configure IBM JVM
-
-When creating a server using the IBM Java Virtual Machine (JVM), you must use a different truststore file than the default truststore installed by the Runtime Manager agent.
-
-. Download the custom truststore from this knowledge base article:
-+
-// Remove this entire section since the KA no longer exists?
-https://help.mulesoft.com/s/article/Connectivity-issues-between-Mule-Runtime-and-Anypoint-Runtime-manager-using-an-IBM-JVM[Connectivity issues between Mule and Anypoint Runtime Manager using an IBM JVM]
-. Depending on your Mule version, rename the `truststore` file in `$MULE_HOME/conf` to one of these file names:
-* `anypoint-truststore.jks` (Mule 4.1.3 with Agent 2.1.4 and later)
-* `truststore.jks` (Mule 4.1.2 with Agent 2.1.3)
-. Copy the custom truststore into the `$MULE_HOME/conf` folder
-. Restart Mule.
 
 == Remove a Server from Another Runtime Manager Instance
 


### PR DESCRIPTION
The Configure IBM JVM section references a knowledge base article that no longer exists and covers an unsupported configuration.

Made-with: Cursor