### PR TITLE
W-21956535-ch2-update-limitations-kt?

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-limits.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-limits.adoc
@@ -41,7 +41,7 @@ Maximum number of Client Certificates in a TLS Context:: There is no limit on th
 +
 A TLS Context can reference one keystore and one truststore, which have their respective file size limits:
 +
-* Truststore maximum file size: 131072 bytes (128 KB)
+* Truststore maximum file size: 40960 bytes (40 KB)
 * Keystore maximum file size for types JKS, JCEKS, PKCS12: 40960 bytes (40 KB).
 * Keystore maximum file size for type PEM:
 ** Certificate File: 4096 bytes (4 KB).


### PR DESCRIPTION

- Updates the truststore maximum file size in the CloudHub 2.0 limits page from 131072 bytes (128 KB) to 40960 bytes (40 KB), per GUS W-21956535.
