### PR TITLE
W-22181302-hyperforce-visualizer-scanners-ca-jp-kt

### DIFF
--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -37,7 +37,7 @@ This table indicates the support status of Anypoint Platform features on Hyperfo
 | Business Groups | Planned | Planned | Available | Available
 | External Identity Management Integration | Planned | Planned | Available | Available
 
-.2+| xref:agent-visualizer::index.adoc[Agent Visualizer]| All other features | Planned | Planned | Planned | Planned .2+| n/a
+.2+| xref:agent-visualizer::index.adoc[Agent Visualizer]| All other features | Planned | Planned | Available | Available .2+| n/a
 | Links to logs and traces | Planned | Planned | Planned | Planned
 
 .5+|xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager]| All other features     |  Planned |Planned | Available | Available .5+|  For details, refer to xref:api-manager::latest-overview-concept.adoc#APIM-hyperforce[API Manager Features by Control Plane],  xref:api-manager::analytics-landing-page.adoc[Mule API Analytics], and xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
@@ -59,7 +59,7 @@ This table indicates the support status of Anypoint Platform features on Hyperfo
                      | AI Documentation Generation      |  Planned |Planned | Available | Available
                       | Amazon Cloud Front      |  Planned |Planned | Planned | Planned
                       | Agent, MCP, and LLM assets (Agent Registry)      |  Planned |Planned | Available | Available
-                      | Agent Scanners      |  Planned |Planned | Planned | Planned
+                      | Agent Scanners      |  Planned |Planned | Available | Available
                       |Usage and Engagement Metrics      |  Planned | Planned |Planned | Planned 
 
 


### PR DESCRIPTION
## Summary
- Updates the Hyperforce feature availability table: marks Agent Visualizer (all other features) and Agent Scanners as Available for CA and JP regions.

## Test plan
- [ ] Verify the updated table renders correctly on the published page.
- [ ] Confirm availability status aligns with the current feature rollout.
