### PR TITLE
W-21611280: Document CH1-to-CH2 migration dual-AZ limitation

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-comparison.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-comparison.adoc
@@ -47,6 +47,7 @@ CloudHub 2.0 infrastructure behavior deviates from CloudHub 1.0 in the following
 * To move applications between regions, you must redeploy the application to another shared space or private space in a different region. You cannot move the app to a different region once deployed.
 * HTTP and HTTPS traffic uses port 8081.
 * You cannot create a VPN connection between a CloudHub 1.0 VPC and a CloudHub 2.0 private space.
+* When migrating from CloudHub 1.0 to CloudHub 2.0, the migration tool discovers two availability zones (AZs) for the CloudHub 1.0 VPC and creates the CloudHub 2.0 private space cluster with two AZs. This results in two sets of inbound and outbound static IP addresses (one per availability zone). Plan your network allowlists and firewall rules accordingly, as your private space will have more IP addresses than a single-AZ configuration.
 
 CloudHub 2.0 does not support the following infrastructure features or functions that CloudHub 1.0 supports:
 


### PR DESCRIPTION
## Summary
- Adds a new bullet under **Infrastructure Considerations** in the CloudHub 2.0 for CloudHub 1.0 Users page (`ch2-comparison.adoc`)
- Documents that during CH1-to-CH2 migration, the migration tool discovers two availability zones for the CH1 VPC and creates the private space cluster with two AZs, resulting in two sets of inbound/outbound static IP addresses per zone
- Advises users to plan network allowlists and firewall rules accordingly

## Test plan
- [ ] Verify the new bullet renders correctly in the AsciiDoc output
- [ ] Confirm the wording accurately reflects the migration tool behavior
- [ ] Check that no existing content is broken by the addition


Made with [Cursor](https://cursor.com)