### PR TITLE
W-22441455-ch2-update-table-control-planes-kt

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/_partials/region-table-long.adoc
+++ b/cloudhub-2/modules/ROOT/pages/_partials/region-table-long.adoc
@@ -1,103 +1,25 @@
-[cols="10,10,15,1,23,22", options="header"]
+[%header%autowidth.spread]
 |===
-|
-|Region
-|Region Name
-|Control Plane
-|Example DNS Record
-|Example Internal DNS Record
+| Control Plane | Geographic Area | Region | Region Name | Example DNS Record | Example Internal DNS Record
 
-.6+|North America
-|US East (N. Virginia)
-|`us-east`
-|US
-|`myapp.usa-e1.cloudhub.io`
-|`<app>.internal-<space-id>.usa-e1.cloudhub.io`
+.12+| US Cloud
+.5+| North America | US East (N. Virginia) | `us-east` | `myapp.usa-e1.cloudhub.io` | `<app>.internal-<space-id>.usa-e1.cloudhub.io`
+| US East (Ohio) | `us-east-2` | `myapp.usa-e2.cloudhub.io` | `<app>.internal-<space-id>.usa-e2.cloudhub.io`
+| US West (N. California) | `us-west` | `myapp.usa-w1.cloudhub.io` | `<app>.internal-<space-id>.usa-w1.cloudhub.io`
+| US West (Oregon) | `us-west-2` | `myapp.usa-w2.cloudhub.io` | `<app>.internal-<space-id>.usa-w2.cloudhub.io`
+| Canada (Montreal) | `can-central` | `myapp.can-c1.cloudhub.io` | `<app>.internal-<space-id>.can-c1.cloudhub.io`
+| South America | Brazil (São Paulo) | `bra-south` | `myapp.bra-s1.cloudhub.io` | `<app>.internal-<space-id>.bra-s1.cloudhub.io`
+.3+| Asia Pacific | Singapore (Singapore) | `ap-southeast` | `myapp.sgp-s1.cloudhub.io` | `<app>.internal-<space-id>.sgp-s1.cloudhub.io`
+| Australia (Sydney) | `ap-southeast-2` | `myapp.aus-s1.cloudhub.io` | `<app>.internal-<space-id>.aus-s1.cloudhub.io`
+| Japan (Tokyo) | `ap-northeast` | `myapp.jpn-e1.cloudhub.io` | `<app>.internal-<space-id>.jpn-e1.cloudhub.io`
+.3+| Europe | Ireland (Dublin) | `eu-west` | `myapp.irl-e1.cloudhub.io` | `<app>.internal-<space-id>.irl-e1.cloudhub.io`
+| Germany (Frankfurt) | `eu-central` | `myapp.deu-c1.cloudhub.io` | `<app>.internal-<space-id>.deu-c1.cloudhub.io`
+| UK (London) | `eu-west-2` | `myapp.gbr-e1.cloudhub.io` | `<app>.internal-<space-id>.gbr-e1.cloudhub.io`
 
-|US East (Ohio)
-|`us-east-2`
-|US
-|`myapp.usa-e2.cloudhub.io`
-|`<app>.internal-<space-id>.usa-e2.cloudhub.io`
+.2+| EU Cloud
+.2+| Europe | Ireland (Dublin) | `eu-west` | `myapp.irl-e1.eu1.cloudhub.io` | -
+| Germany (Frankfurt) | `eu-central` | `myapp.deu-c1.eu1.cloudhub.io` | -
 
-|US West (N. California)
-|`us-west`
-|US
-|`myapp.usa-w1.cloudhub.io`
-|`<app>.internal-<space-id>.usa-w1.cloudhub.io`
-
-|US West (Oregon)
-|`us-west-2`
-|US
-|`myapp.usa-w2.cloudhub.io`
-|`<app>.internal-<space-id>.usa-w2.cloudhub.io`
-
-|Canada (Central)
-|`can-central`
-|US
-|`myapp.can-c1.cloudhub.io`
-|`<app>.internal-<space-id>.can-c1.cloudhub.io`
-
-|US GovCloud (West)
-|`us-gov-west`
-|US Gov
-|`myapp.usg-w1.gov.cloudhub.io`
-| -
-
-.1+|South America
-|Brazil (São Paulo)
-|`bra-south`
-|US
-|`myapp.bra-s1.cloudhub.io`
-|`<app>.internal-<space-id>.bra-s1.cloudhub.io`
-
-.3+|APAC
-|Singapore
-|`ap-southeast`
-|US
-|`myapp.sgp-s1.cloudhub.io`
-|`<app>.internal-<space-id>.sgp-s1.cloudhub.io`
-
-|Australia (Sydney)
-|`ap-southeast-2`
-|US
-|`myapp.aus-s1.cloudhub.io`
-|`<app>.internal-<space-id>.aus-s1.cloudhub.io`
-
-|Japan (Tokyo)
-|`ap-northeast`
-|US
-|`myapp.jpn-e1.cloudhub.io`
-|`<app>.internal-<space-id>.jpn-e1.cloudhub.io`
-
-.5+|Europe
-|Ireland
-|`eu-west`
-|US
-|`myapp.irl-e1.cloudhub.io`
-|`<app>.internal-<space-id>.irl-e1.cloudhub.io`
-
-|EU (Frankfurt)
-|`eu-central`
-|US
-|`myapp.deu-c1.cloudhub.io`
-|`<app>.internal-<space-id>.deu-c1.cloudhub.io`
-
-|UK (London)
-|`eu-west-2`
-|US
-|`myapp.gbr-e1.cloudhub.io`
-|`<app>.internal-<space-id>.gbr-e1.cloudhub.io`
-
-|Ireland (EU Control Plane)
-|`eu-west`
-|EU
-|`myapp.irl-e1.eu1.cloudhub.io`
-| -
-
-|Germany (EU Control Plane)
-|`eu-central`
-|EU
-|`myapp.deu-c1.eu1.cloudhub.io`
-| -
+| MuleSoft Government Cloud
+| US Government | US GovCloud (West) | `us-gov-west` | `myapp.usg-w1.gov.cloudhub.io` | -
 |===

--- a/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
@@ -135,32 +135,36 @@ The load balancer that CloudHub 2.0 uses to route requests resides in the same r
 Depending on what region you deploy your application in, the DNS record and the load balancer for your integration might change.
 The following table summarizes what DNS records are available for your application in each region:
 
-[%header,cols="15a,10a,30a,40a,40a"]
+[%header%autowidth.spread]
 |===
-| Region Name | Region | Target ID | Example DNS Record | Target Name
-5+h| US Cloud: Runtime Plane Regions
-| US East (N. Virginia) |usa-e1 | `cloudhub-us-east-1` | `myapp-_uniq-id_._shard_.usa-e1.cloudhub.io` | `Cloudhub-US-East-1`
-| US East (Ohio) |usa-e2| `cloudhub-us-east-2` | `myapp-_uniq-id_._shard_.usa-e2.cloudhub.io` | `Cloudhub-US-East-2`
-| US West (N. California) |usa-w1 |`cloudhub-us-west-1` | `myapp-_uniq-id_._shard_.usa-w1.cloudhub.io` | `Cloudhub-US-West-1`
-| US West (Oregon) |usa-w2| `cloudhub-us-west-2` | `myapp-_uniq-id_._shard_.usa-w2.cloudhub.io` | `Cloudhub-US-West-2`
-| Canada (Central) |can-c1| `cloudhub-ca-central-1` | `myapp-_uniq-id_._shard_.can-c1.cloudhub.io` | `Cloudhub-CA-Central-1`
-| South America (Sao Paulo) |bra-s1| `cloudhub-sa-east-1` | `myapp-_uniq-id_._shard_.bra-s1.cloudhub.io` | `Cloudhub-SA-East-1`
-| Asia Pacific (Singapore) |sgp-s1| `cloudhub-ap-southeast-1` | `myapp-_uniq-id_._shard_.sgp-s1.cloudhub.io` | `Cloudhub-AP-Southeast-1`
-| Asia Pacific (Sydney) |aus-s1| `cloudhub-ap-southeast-2` | `myapp-_uniq-id_._shard_.aus-s1.cloudhub.io` | `Cloudhub-AP-Southeast-2`
-| Asia Pacific (Tokyo) |jpn-e1| `cloudhub-ap-northeast-1` | `myapp-_uniq-id_._shard_.jpn-e1.cloudhub.io` | `Cloudhub-AP-Northeast-1`
-| EU (Ireland) |irl-e1 | `cloudhub-eu-west-1` | `myapp-_uniq-id_._shard_.irl-e1.cloudhub.io` | `Cloudhub-EU-West-1`
-| EU (Frankfurt) |deu-c1 | `cloudhub-eu-central-1` | `myapp-_uniq-id_._shard_.deu-c1.cloudhub.io` | `Cloudhub-EU-Central-1`
-| UK (London) |gbr-e1 | `cloudhub-eu-west-2` | `myapp-_uniq-id_._shard_.gbr-e1.cloudhub.io` | `Cloudhub-EU-West-2`
-5+h| EU Cloud: Runtime Plane Regions
-| EU (Ireland) |irl-e1.eu1 | `cloudhub-eu-west-1` | `myapp-_uniq-id_._shard_.irl-e1.eu1.cloudhub.io` | `Cloudhub-EU-West-1`
-| EU (Frankfurt) |deu-c1.eu1 | `cloudhub-eu-central-1` | `myapp-_uniq-id_._shard_.deu-c1.eu1.cloudhub.io` | `Cloudhub-EU-Central-1`
-5+h| Canada Cloud: Runtime Plane Regions
-| Canada (Central) |can-c1| `cloudhub-ca-central-1` | `myapp-uniq-id.can-c1.ca1.cloudhub.io` | `Cloudhub-CA-Central-1`
-5+h| Japan Cloud: Runtime Plane Regions
-| Asia Pacific (Tokyo) |jpn-e1| `cloudhub-ap-northeast-1` | `myapp-uniq-id.jpn-e1.jp1.cloudhub.io` | `Cloudhub-AP-Northeast-1`
+| Control Plane | Geographic Area | Region Name | Region | Target ID | Example DNS Record | Target Name
+
+.12+| US Cloud
+.5+| North America | US East (N. Virginia) | usa-e1 | `cloudhub-us-east-1` | `myapp-_uniq-id_._shard_.usa-e1.cloudhub.io` | `Cloudhub-US-East-1`
+| US East (Ohio) | usa-e2 | `cloudhub-us-east-2` | `myapp-_uniq-id_._shard_.usa-e2.cloudhub.io` | `Cloudhub-US-East-2`
+| US West (N. California) | usa-w1 | `cloudhub-us-west-1` | `myapp-_uniq-id_._shard_.usa-w1.cloudhub.io` | `Cloudhub-US-West-1`
+| US West (Oregon) | usa-w2 | `cloudhub-us-west-2` | `myapp-_uniq-id_._shard_.usa-w2.cloudhub.io` | `Cloudhub-US-West-2`
+| Canada (Montreal) | can-c1 | `cloudhub-ca-central-1` | `myapp-_uniq-id_._shard_.can-c1.cloudhub.io` | `Cloudhub-CA-Central-1`
+| South America | Brazil (São Paulo) | bra-s1 | `cloudhub-sa-east-1` | `myapp-_uniq-id_._shard_.bra-s1.cloudhub.io` | `Cloudhub-SA-East-1`
+.3+| Asia Pacific | Singapore (Singapore) | sgp-s1 | `cloudhub-ap-southeast-1` | `myapp-_uniq-id_._shard_.sgp-s1.cloudhub.io` | `Cloudhub-AP-Southeast-1`
+| Australia (Sydney) | aus-s1 | `cloudhub-ap-southeast-2` | `myapp-_uniq-id_._shard_.aus-s1.cloudhub.io` | `Cloudhub-AP-Southeast-2`
+| Japan (Tokyo) | jpn-e1 | `cloudhub-ap-northeast-1` | `myapp-_uniq-id_._shard_.jpn-e1.cloudhub.io` | `Cloudhub-AP-Northeast-1`
+.3+| Europe | Ireland (Dublin) | irl-e1 | `cloudhub-eu-west-1` | `myapp-_uniq-id_._shard_.irl-e1.cloudhub.io` | `Cloudhub-EU-West-1`
+| Germany (Frankfurt) | deu-c1 | `cloudhub-eu-central-1` | `myapp-_uniq-id_._shard_.deu-c1.cloudhub.io` | `Cloudhub-EU-Central-1`
+| UK (London) | gbr-e1 | `cloudhub-eu-west-2` | `myapp-_uniq-id_._shard_.gbr-e1.cloudhub.io` | `Cloudhub-EU-West-2`
+
+.2+| EU Cloud
+.2+| Europe | Ireland (Dublin) | irl-e1.eu1 | `cloudhub-eu-west-1` | `myapp-_uniq-id_._shard_.irl-e1.eu1.cloudhub.io` | `Cloudhub-EU-West-1`
+| Germany (Frankfurt) | deu-c1.eu1 | `cloudhub-eu-central-1` | `myapp-_uniq-id_._shard_.deu-c1.eu1.cloudhub.io` | `Cloudhub-EU-Central-1`
+
+| Canada Cloud
+| North America | Canada (Montreal) | can-c1 | `cloudhub-ca-central-1` | `myapp-uniq-id.can-c1.ca1.cloudhub.io` | `Cloudhub-CA-Central-1`
+
+| Japan Cloud
+| Asia Pacific | Japan (Tokyo) | jpn-e1 | `cloudhub-ap-northeast-1` | `myapp-uniq-id.jpn-e1.jp1.cloudhub.io` | `Cloudhub-AP-Northeast-1`
 |===
 
-For example, if you deploy an application named `myapp` to Canada (Central), the domain used to access the application is `myapp-_uniq-id_._shard_.can-c1.cloudhub.io`.
+For example, if you deploy an application named `myapp` to Canada (Montreal), the domain used to access the application is `myapp-_uniq-id_._shard_.can-c1.cloudhub.io`.
 
 include::partial$url-format-by-control-plane.adoc[]
 

--- a/hosting-home/modules/ROOT/pages/index.adoc
+++ b/hosting-home/modules/ROOT/pages/index.adoc
@@ -73,9 +73,9 @@ This table lists the runtime regions available for each control plane:
 | US East (Ohio) | `us-east-2`
 | US West (N. California) | `us-west`
 | US West (Oregon) | `us-west-2`
-| Canada (Central) | `ca-central`
+| Canada (Montreal) | `ca-central`
 | South America | Brazil (São Paulo) | `br-south`
-.3+| Asia Pacific | Singapore | `ap-southeast`
+.3+| Asia Pacific | Singapore (Singapore) | `ap-southeast`
 | Australia (Sydney) | `ap-southeast-2`
 | Japan (Tokyo) | `ap-northeast`
 .3+| Europe | Ireland (Dublin) | `eu-west`


### PR DESCRIPTION
Restructure region-table-long.adoc and ch2-architecture.adoc tables to group by control plane first (matching hosting-home index.adoc pattern). Standardize region names to Country (City) format across all three tables.