### PR TITLE
W-22441455-ch2-table-updates-platformurl-kt

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/_partials/region-table-long.adoc
+++ b/cloudhub-2/modules/ROOT/pages/_partials/region-table-long.adoc
@@ -2,7 +2,7 @@
 |===
 | Control Plane | Geographic Area | Region | Region Name | Example DNS Record | Example Internal DNS Record
 
-.12+| US Cloud
+.12+| https://anypoint.mulesoft.com[US Cloud]
 .5+| North America | US East (N. Virginia) | `us-east` | `myapp.usa-e1.cloudhub.io` | `<app>.internal-<space-id>.usa-e1.cloudhub.io`
 | US East (Ohio) | `us-east-2` | `myapp.usa-e2.cloudhub.io` | `<app>.internal-<space-id>.usa-e2.cloudhub.io`
 | US West (N. California) | `us-west` | `myapp.usa-w1.cloudhub.io` | `<app>.internal-<space-id>.usa-w1.cloudhub.io`
@@ -16,10 +16,10 @@
 | Germany (Frankfurt) | `eu-central` | `myapp.deu-c1.cloudhub.io` | `<app>.internal-<space-id>.deu-c1.cloudhub.io`
 | UK (London) | `eu-west-2` | `myapp.gbr-e1.cloudhub.io` | `<app>.internal-<space-id>.gbr-e1.cloudhub.io`
 
-.2+| EU Cloud
+.2+| https://eu1.anypoint.mulesoft.com[EU Cloud]
 .2+| Europe | Ireland (Dublin) | `eu-west` | `myapp.irl-e1.eu1.cloudhub.io` | -
 | Germany (Frankfurt) | `eu-central` | `myapp.deu-c1.eu1.cloudhub.io` | -
 
-| MuleSoft Government Cloud
+| https://gov.anypoint.mulesoft.com[MuleSoft Government Cloud]
 | US Government | US GovCloud (West) | `us-gov-west` | `myapp.usg-w1.gov.cloudhub.io` | -
 |===

--- a/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
@@ -139,7 +139,7 @@ The following table summarizes what DNS records are available for your applicati
 |===
 | Control Plane | Geographic Area | Region Name | Region | Target ID | Example DNS Record | Target Name
 
-.12+| US Cloud
+.12+| https://anypoint.mulesoft.com[US Cloud]
 .5+| North America | US East (N. Virginia) | usa-e1 | `cloudhub-us-east-1` | `myapp-_uniq-id_._shard_.usa-e1.cloudhub.io` | `Cloudhub-US-East-1`
 | US East (Ohio) | usa-e2 | `cloudhub-us-east-2` | `myapp-_uniq-id_._shard_.usa-e2.cloudhub.io` | `Cloudhub-US-East-2`
 | US West (N. California) | usa-w1 | `cloudhub-us-west-1` | `myapp-_uniq-id_._shard_.usa-w1.cloudhub.io` | `Cloudhub-US-West-1`
@@ -153,14 +153,14 @@ The following table summarizes what DNS records are available for your applicati
 | Germany (Frankfurt) | deu-c1 | `cloudhub-eu-central-1` | `myapp-_uniq-id_._shard_.deu-c1.cloudhub.io` | `Cloudhub-EU-Central-1`
 | UK (London) | gbr-e1 | `cloudhub-eu-west-2` | `myapp-_uniq-id_._shard_.gbr-e1.cloudhub.io` | `Cloudhub-EU-West-2`
 
-.2+| EU Cloud
+.2+| https://eu1.anypoint.mulesoft.com[EU Cloud]
 .2+| Europe | Ireland (Dublin) | irl-e1.eu1 | `cloudhub-eu-west-1` | `myapp-_uniq-id_._shard_.irl-e1.eu1.cloudhub.io` | `Cloudhub-EU-West-1`
 | Germany (Frankfurt) | deu-c1.eu1 | `cloudhub-eu-central-1` | `myapp-_uniq-id_._shard_.deu-c1.eu1.cloudhub.io` | `Cloudhub-EU-Central-1`
 
-| Canada Cloud
+| https://ca1.platform.mulesoft.com[Canada Cloud]
 | North America | Canada (Montreal) | can-c1 | `cloudhub-ca-central-1` | `myapp-uniq-id.can-c1.ca1.cloudhub.io` | `Cloudhub-CA-Central-1`
 
-| Japan Cloud
+| https://jp1.platform.mulesoft.com[Japan Cloud]
 | Asia Pacific | Japan (Tokyo) | jpn-e1 | `cloudhub-ap-northeast-1` | `myapp-uniq-id.jpn-e1.jp1.cloudhub.io` | `Cloudhub-AP-Northeast-1`
 |===
 

--- a/hosting-home/modules/ROOT/pages/index.adoc
+++ b/hosting-home/modules/ROOT/pages/index.adoc
@@ -68,7 +68,7 @@ This table lists the runtime regions available for each control plane:
 |===
 | Control Plane | Geographic Area | Region | Region Name
 
-.12+| US Cloud
+.12+| https://anypoint.mulesoft.com[US Cloud]
 .5+| North America | US East (N. Virginia) | `us-east`
 | US East (Ohio) | `us-east-2`
 | US West (N. California) | `us-west`
@@ -82,17 +82,17 @@ This table lists the runtime regions available for each control plane:
 | Germany (Frankfurt) | `eu-central`
 | UK (London) | `eu-west-2`
 
-.2+| EU Cloud
+.2+| https://eu1.anypoint.mulesoft.com[EU Cloud]
 .2+| Europe | Ireland (Dublin) | `eu-west`
 | Germany (Frankfurt) | `eu-central`
 
-| Canada Cloud
+| https://ca1.platform.mulesoft.com[Canada Cloud]
 | North America | Canada (Montreal) | `ca-central-1`
 
-| Japan Cloud
+| https://jp1.platform.mulesoft.com[Japan Cloud]
 | Asia Pacific | Japan (Tokyo) | `ap-northeast-1`
 
-| MuleSoft Government Cloud
+| https://gov.anypoint.mulesoft.com[MuleSoft Government Cloud]
 | US Government | US GovCloud (West) | `us-gov-west`
 |===
 


### PR DESCRIPTION
Embed the Anypoint Platform URLs as links on the Control Plane column values across all three region tables (region-table-long, ch2-architecture, hosting-home index).