### PR TITLE
W-22510098: Fix 'public space' typos in CH2 endpoint definitions

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-config-endpoints-paths.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-config-endpoints-paths.adoc
@@ -8,8 +8,8 @@ A private space routes requests from clients to apps deployed to the private spa
 
 When you deploy an app to a private space, CloudHub 2.0 creates two types of _endpoints_ by default:
 
-* *Endpoint*: A URL used to reach the app deployed to the public space. In this context, it's accessible externally and enables clients outside the network to reach the app. You can delete this endpoint to prevent external traffic from reaching the app.
-* *Internal endpoint*: A URL used to reach the app deployed to the public space, but it's accessible only within the private network, VPN, or transit gateway (TGW). You can't modify or delete this type of endpoint.
+* *Endpoint*: A URL used to reach the app deployed to the private space. In this context, it's accessible externally and enables clients outside the network to reach the app. You can delete this endpoint to prevent external traffic from reaching the app.
+* *Internal endpoint*: A URL used to reach the app deployed to the private space, but it's accessible only within the private network, VPN, or transit gateway (TGW). You can't modify or delete this type of endpoint.
 
 An example endpoint URL is `\https://my-app.example.com/`. To ensure an app is accessible only within the network, use internal endpoints.
 


### PR DESCRIPTION
## Summary
- Fixes two typos on the `ch2-config-endpoints-paths` page where "public space" was incorrectly used instead of "private space" in the endpoint and internal endpoint definitions.
- GUS: W-22510098

## Test plan
- [ ] Verify the endpoint definition now correctly says "private space"
- [ ] Verify the internal endpoint definition now correctly says "private space"
- [ ] Confirm no other content was changed


Made with [Cursor](https://cursor.com)