### PR TITLE
W-22710322: Revert HPA eligibility note to new pricing model wording

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-configure-horizontal-autoscaling.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-configure-horizontal-autoscaling.adoc
@@ -7,7 +7,7 @@ Configure CPU-based horizontal scaling for Mule applications to make them respon
 
 [NOTE]
 ====
-This feature is available to organizations with an Enterprise License Agreement (ELA) or those opted into the new pricing and packaging model. If the Horizontal Pod Autoscaling option is not visible in the Runtime Manager UI, contact your account team.
+This feature applies only to customers who are opted into the new pricing and packaging model. For more details, see xref:general::pricing.adoc[]
 ====
 
 In Kubernetes, a Horizontal Pod Autoscaler (HPA) automatically updates a workload resource to scale the workload to match demand. Horizontal scaling automatically deploys more pods as a response to an increased load. For more information, visit the https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/[Kubernetes documentaton^]. 


### PR DESCRIPTION
## Summary
- Reverts the HPA eligibility note in `ch2-configure-horizontal-autoscaling.adoc` to state that the feature applies only to customers opted into the new pricing and packaging model, linking to the pricing page for details.

## Test plan
- [ ] Verify the rendered note displays correctly and the `xref:general::pricing.adoc[]` link resolves.

Made with [Cursor](https://cursor.com)