### PR TITLE
W-23021928: Fix Anypoint Monitoring cell span in Hyperforce India cloud tables

### DIFF
--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -74,7 +74,7 @@ Americas::
 | Agent Scanners | Planned | Available
 | Usage and Engagement Metrics | Planned | Planned
 
-.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .12+a| For details, refer to:
+.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .13+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 * xref:monitoring::logs-search-hf.adoc[Log Search on Hyperforce]
@@ -433,7 +433,7 @@ Asia Pacific::
 | Agent Scanners | Available | Available
 | Usage and Engagement Metrics | Planned | Available
 
-.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .12+a| For details, refer to:
+.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .13+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 * xref:monitoring::logs-search-hf.adoc[Log Search on Hyperforce]


### PR DESCRIPTION
## Summary
- Fix the rowspan on the Anypoint Monitoring rows in the Hyperforce India cloud feature tables (Americas and Asia Pacific sections).
- Updated the AsciiDoc cell span from `.12+` to `.13+` so the "For details, refer to:" cell correctly spans all of its associated feature rows.

## Test plan
- [ ] Build/preview the `hyperforce/modules/ROOT/pages/index.adoc` page and confirm the Anypoint Monitoring "details" cell spans all 13 feature rows without table misalignment.

Made with [Cursor](https://cursor.com)