### PR TITLE
W-23072304: Update CloudHub 2.0 docs for India Cloud

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/_partials/url-format-by-control-plane.adoc
+++ b/cloudhub-2/modules/ROOT/pages/_partials/url-format-by-control-plane.adoc
@@ -4,7 +4,7 @@ URL formats vary by control plane:
 
 US Cloud Control Plane:: URLs don't include a region suffix before `cloudhub.io`. +
 Example: `myapp.usa-e1.cloudhub.io`
-Non-US Control Planes:: URLs include a region suffix (such as `eu1`, `ca1`, or `jp1`) before `cloudhub.io`. +
-Examples: `myapp.irl-e1.eu1.cloudhub.io`, `myapp.can-c1.ca1.cloudhub.io`, `myapp.jpn-e1.jp1.cloudhub.io`
+Non-US Control Planes:: URLs include a region suffix (such as `eu1`, `ca1`, `jp1`, or `in1`) before `cloudhub.io`. +
+Examples: `myapp.irl-e1.eu1.cloudhub.io`, `myapp.can-c1.ca1.cloudhub.io`, `myapp.jpn-e1.jp1.cloudhub.io`, `myapp.ind-w1.in1.cloudhub.io`
 ====
 

--- a/cloudhub-2/modules/ROOT/pages/index.adoc
+++ b/cloudhub-2/modules/ROOT/pages/index.adoc
@@ -6,7 +6,7 @@ CloudHub 2.0 is a fully managed, containerized integration platform as a service
 
 CloudHub 2.0:
 
-* Provides for deployments across 12 regions globally.
+* Supports deployments across all the MuleSoft regions.
 * Dynamically scales infrastructure and built-in services up or down to support elastic transaction volumes.
 * Builds in security policies, protecting your services and sensitive data with encrypted secrets, firewall controls, and restricted shell access.
 * Encrypts certificates, passwords, and other sensitive configuration data at rest and in transit within Anypoint Platform.
@@ -21,14 +21,15 @@ All CloudHub 2.0 features are supported across all control planes, with a few ex
 
 * Deleting the default egress traffic route (0.0.0.0) can cause Anypoint Monitoring to fail in CloudHub 2.0.
 * The endpoint URL format requires the region suffix or not before `cloudhub.io`.
+* A different Ingress controller is used in India Cloud. It maintains feature parity, but has some behavior differences. Read this link:https://help.salesforce.com/s/articleView?id=005387259&type=1[knowledge article].
 
-[cols="~,15,20,20,20"]
+[cols="~,15,20,20,20,20"]
 |===
-|CloudHub 2.0 Features |US Cloud |EU Cloud |Canada Cloud |Japan Cloud
+|CloudHub 2.0 Features |US Cloud |EU Cloud |Canada Cloud |Japan Cloud |India Cloud
 
-| Deleting the Default Route| Available | Available | Not Available | Not Available
+| Deleting the Default Route| Available | Available | Not Available | Not Available | Not Available
 
-| Endpoints URL Format| No region suffix: `https://*.10u6w7.usa-e1.cloudhub.io`| Needs region suffix: `https://*.10u6w7.usa-e1.eu1.cloudhub.io` | Needs region suffix: `https://*.10u6w7.ca-c1.cloudhub.io` | Needs region suffix: `https://*.10u6w7.jp-e1.cloudhub.io`
+| Endpoints URL Format| No region suffix: `https://*.10u6w7.usa-e1.cloudhub.io`| Needs region suffix: `https://*.10u6w7.usa-e1.eu1.cloudhub.io` | Needs region suffix: `https://*.10u6w7.can-c1.ca1.cloudhub.io` | Needs region suffix: `https://*.10u6w7.jpn-e1.jp1.cloudhub.io` | Needs region suffix: `https://*.10u6w7.ind-w1.in1.cloudhub.io`
 |=== 
 
 

--- a/cloudhub-2/modules/ROOT/pages/index.adoc
+++ b/cloudhub-2/modules/ROOT/pages/index.adoc
@@ -6,7 +6,7 @@ CloudHub 2.0 is a fully managed, containerized integration platform as a service
 
 CloudHub 2.0:
 
-* Supports deployments across all the MuleSoft regions.
+* Supports deployments across all MuleSoft regions.
 * Dynamically scales infrastructure and built-in services up or down to support elastic transaction volumes.
 * Builds in security policies, protecting your services and sensitive data with encrypted secrets, firewall controls, and restricted shell access.
 * Encrypts certificates, passwords, and other sensitive configuration data at rest and in transit within Anypoint Platform.

--- a/cloudhub-2/modules/ROOT/pages/index.adoc
+++ b/cloudhub-2/modules/ROOT/pages/index.adoc
@@ -21,7 +21,7 @@ All CloudHub 2.0 features are supported across all control planes, with a few ex
 
 * Deleting the default egress traffic route (0.0.0.0) can cause Anypoint Monitoring to fail in CloudHub 2.0.
 * The endpoint URL format requires the region suffix or not before `cloudhub.io`.
-* A different Ingress controller is used in India Cloud. It maintains feature parity, but has some behavior differences. Read this link:https://help.salesforce.com/s/articleView?id=005387259&type=1[knowledge article].
+* India Cloud uses a different Ingress controller. It maintains feature parity, but has some behavioral differences. Read this link:https://help.salesforce.com/s/articleView?id=005387259&type=1[knowledge article].
 
 [cols="~,15,20,20,20,20"]
 |===


### PR DESCRIPTION
## Summary

- Adds India Cloud column to the Features by Control Plane table with correct endpoint URL (`https://*.10u6w7.ind-w1.in1.cloudhub.io`) and "Not Available" for Deleting the Default Route
- Adds a bullet point noting India Cloud uses a different Ingress controller (links to knowledge article 005387259)
- Fixes pre-existing typos in Canada (`ca-c1` → `can-c1`) and Japan (`jp-e1` → `jpn-e1`) endpoint URLs in the table
- Adds `in1` to the region suffix list and examples in the URL format note partial
- Updates "12 regions globally" to "all the MuleSoft regions"

## Test plan

- [ ] Verify India Cloud column renders correctly in the features table on the CloudHub 2.0 index page
- [ ] Confirm the knowledge article link resolves (articleView?id=005387259)
- [ ] Check URL format note partial renders with updated examples on all pages that include it