### PR TITLE
W-23093732: Update Deleting the Default Egress Route to Available for Canada and Japan Cloud

### DIFF
--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -147,13 +147,13 @@ Americas::
 
 * xref:cloudhub-2::index.adoc#cloudhub2-hyperforce[CloudHub 2.0 Features by Control Plane]
 * xref:cloudhub-2::ch2-architecture.adoc#regions-and-dns-records[Runtime Plane Regions and DNS Records]
-| Deleting the Default Egress Route | Planned | Planned
+| Deleting the Default Egress Route | Planned | Available
 | Global Cloud Deployment | Planned | Not planned
 | Private Space | Planned | Available
 | Private Space - VPN | Planned | Available
 | Shared Spaces | Planned | Available
 
-| xref:connectors::index.adoc[Connectors] |  | Planned | Available | 
+| xref:connectors::index.adoc[Connectors] |  | Planned | Available |
 
 | xref:dataweave::index.adoc[DataWeave] | n/a | Planned | Available | n/a
 
@@ -489,7 +489,7 @@ Asia Pacific::
 
 * xref:cloudhub-2::index.adoc#cloudhub2-hyperforce[CloudHub 2.0 Features by Control Plane]
 * xref:cloudhub-2::ch2-architecture.adoc#regions-and-dns-records[Runtime Plane Regions and DNS Records]
-| Deleting the Default Egress Route | Planned | Available
+| Deleting the Default Egress Route | Available | Available
 | Global Cloud Deployment | Not planned | Not planned
 | Private Space | Available | Available
 | Private Space - VPN | Available | Available


### PR DESCRIPTION
## Summary
- Updated "Deleting the Default Egress Route" status to **Available** for Canada Cloud in the Americas table
- Updated "Deleting the Default Egress Route" status to **Available** for Japan Cloud in the Asia Pacific table

## Test plan
- [ ] Verify Canada Cloud column shows "Available" for "Deleting the Default Egress Route" in the Americas features table
- [ ] Verify Japan Cloud column shows "Available" for "Deleting the Default Egress Route" in the Asia Pacific features table