### PR TITLE
W-23093732: Update API Manager notes and Reports availability

### DIFF
--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -37,14 +37,17 @@ Americas::
 |===
 |Component |Feature Description |US Cloud |Canada Cloud |Notes
 
+//ACCESS MANAGEMENT - AMERICAS: US | CANADA
 .4+| xref:access-management::index.adoc[Access Management] | All other features | Planned | Available .4+| n/a
 | Audit Logging | Planned | Available
 | Business Groups | Planned | Available
 | External Identity Management Integration | Planned | Available
 
+//AGENT VISUALIZER - AMERICAS: US | CANADA
 .2+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Planned | Available .2+| n/a
 | Links to logs and traces | Planned | Planned
 
+//API MANAGER - AMERICAS: US | CANADA
 .6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned | Available .6+a| n/a
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
@@ -54,15 +57,18 @@ Americas::
 | API Manager 2.x | Planned | Available
 | API Console Proxy/Trusted Domains | Planned | Planned
 
+//CLI - AMERICAS: US | CANADA
 .2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Planned | Available .2+| n/a
 | API Catalog CLI | Planned | Available
 
+//CODE BUILDER - AMERICAS: US | CANADA
 .5+| xref:anypoint-code-builder::index.adoc[Anypoint Code Builder] | All other features | Planned | Available .5+| For details, refer to xref:anypoint-code-builder::index.adoc#us-eu-clouds[Anypoint Code Builder Cloud Hosts]
 | Agent Network Projects (Agent Broker) | Planned | Available
 | MuleSoft Vibes | Planned | Available
 | Generative Data Transformations | Planned | Available
 | Generative MUnit | Planned | Available
 
+//EXCHANGE - AMERICAS: US | CANADA
 .5+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Planned | Available .5+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
 | AI Documentation Generation | Planned | Available
 | Amazon Cloud Front | Planned | Planned
@@ -76,16 +82,17 @@ Americas::
 //MONITORING - AMERICAS: US | CANADA
 | Basic Alerts | Planned | Planned
 | Basic Monitoring | Available | Available
-| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned
-| Standard Dashboards (Anypoint Insights) | Available | Available
 | Custom Dashboards | Available | Planned
-| Traces Beta | Available | Not planned
-| Telemetry Exporter | Available | Available
+| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned
+| Integration Intelligence | Planned | Available
 | Log Search | Available | Available (Beta)
 | Log Tailing | Planned | Available
-| Integration Intelligence | Planned | Available
 | Reports | Available | Available
+| Standard Dashboards (Anypoint Insights) | Available | Available
+| Telemetry Exporter | Available | Available
+| Traces Beta | Available | Not planned
 
+//MQ - AMERICAS: US | CANADA
 .18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Planned | Available .18+a| For details, refer to:
 
 * xref:mq::index.adoc#mq-features-control-plane[Anypoint MQ Features by Control Plane]
@@ -109,38 +116,52 @@ Americas::
 | Usage Charts (Access Management) | Not planed | Not planned
 | Usage Reports (Usage) | Planned | Available
 
+//PARTNER MANAGER - AMERICAS: US | CANADA
 .2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Planned | Available .2+| n/a
 | Generative B2B Message Summary Feature | Planned | Available
 
+//PRIVATE CLOUD EDITION - AMERICAS: US | CANADA
 | xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
+//RUNTIME MANAGER - AMERICAS: US | CANADA
 .3+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Planned | Available .3+| n/a
 | Insights | Not planned | Not planned
 | Monitoring for Hybrid Standalone Deployments | Planned | Not planned
 
+//SECURITY SECRETS MANAGER - AMERICAS: US | CANADA
 | xref:anypoint-security::index-secrets-manager.adoc[Anypoint Security Secrets Manager] | n/a | Planned | Available | n/a
 
+//STUDIO - AMERICAS: US | CANADA
 | xref:studio::index.adoc[Anypoint Studio] | n/a | Planned | Available | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
 
+//API VISUALIZER - AMERICAS: US | CANADA
 .3+| xref:visualizer::index.adoc[API Visualizer] | Architecture | Planned | Available .3+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
 | Policies | Planned | Available
 | Troubleshooting | Planned | Planned
 
+//API COMMUNITY MANAGER - AMERICAS: US | CANADA
 | xref:api-community-manager::index.adoc[API Community Manager] | n/a | Planned | Available | n/a
 
+//API DESIGNER - AMERICAS: US | CANADA
 | xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Planned | Not planned | n/a
 
+//API EXPERIENCE HUB - AMERICAS: US | CANADA
 | xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Planned | Available | n/a
 
+//API FUNCTIONAL MONITORING - AMERICAS: US | CANADA
 | xref:api-functional-monitoring::index.adoc[API Functional Monitoring] | n/a | Planned | Available | n/a
 
+//API GOVERNANCE - AMERICAS: US | CANADA
 | xref:api-governance::index.adoc[API Governance] | n/a | Planned | Available | n/a
 
+//API MOCKING SERVICE - AMERICAS: US | CANADA
 | xref:design-center::design-mocking-service.adoc[API Mocking Service] | n/a | Planned | Available | n/a
 
+//CLOUDHUB - AMERICAS: US | CANADA
 .2+| xref:cloudhub::index.adoc[CloudHub] | All other features | Planned | Not planned .2+| n/a
 | Global CloudHub Deployment | Planned | Not planned
 
+//CLOUDHUB 2.0 - AMERICAS: US | CANADA
 .6+| xref:cloudhub-2::index.adoc[CloudHub 2.0] | All other features | Planned | Available .6+a| For details, refer to:
 
 * xref:cloudhub-2::index.adoc#cloudhub2-hyperforce[CloudHub 2.0 Features by Control Plane]
@@ -151,31 +172,42 @@ Americas::
 | Private Space - VPN | Planned | Available
 | Shared Spaces | Planned | Available
 
+//CONNECTORS - AMERICAS: US | CANADA
 | xref:connectors::index.adoc[Connectors] |  | Planned | Available |
 
+//DATAWEAVE - AMERICAS: US | CANADA
 | xref:dataweave::index.adoc[DataWeave] | n/a | Planned | Available | n/a
 
+//DATALOADER - AMERICAS: US | CANADA
 | Dataloader | n/a | Planned | Not planned | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
 
+//ENHANCED MULESOFT EXPERIENCE AND REMOTE MCP SERVER - AMERICAS: US | CANADA
 | xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Planned | Available | n/a
 
+//OMNI GATEWAY - AMERICAS: US | CANADA
 .4+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned | Available .4+| n/a
 | Managed Omni Gateway on Runtime Fabric | Planned | Available
 | Self-Managed - Connected Mode | Planned | Available
 | Self-Managed - Local Mode | Planned | Available
 
+//HYBRID STANDALONE DEPLOYMENT - AMERICAS: US | CANADA
 | xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | Planned | n/a
 
+//IDP - AMERICAS: US | CANADA
 | xref:idp::index.adoc[IDP] | n/a | Planned | Not planned | n/a
 
+//MULE GATEWAY - AMERICAS: US | CANADA
 .2+| xref:gateway-home::index.adoc#anypoint_mule_gateway[Mule Gateway] | Mule Gateway Proxies | Planned | Available .2+| n/a
 | Mule Gateway Policies | Planned | Available
 
+//MULE RUNTIME ENGINE - AMERICAS: US | CANADA
 .2+| xref:mule-runtime::index.adoc[Mule runtime engine] | All features | Planned | Available .2+| Mule 3 is not supported as it reached EOL.
 | Diagnostics Agent | Planned | Available
 
+//MUNIT - AMERICAS: US | CANADA
 | xref:munit::index.adoc[MUnit] | All features | Planned | Available | n/a
 
+//OBJECT STORE V2 - AMERICAS: US | CANADA
 .6+| xref:object-store::index.adoc[Object Store V2] | All other features | Planned | Available .6+a| For details, refer to:
 
 * xref:object-store::index.adoc#os-features-control-plane[Object Store Features by Control Plane]
@@ -186,8 +218,10 @@ Americas::
 | Usage Reports (Usage) | Planned | Available
 | Usage Charts (Access Management) | Not planned | Not planned
 
+//RPA - AMERICAS: US | CANADA
 | xref:rpa-home::index.adoc[RPA] | n/a | Planned | Not planned | n/a
 
+//RUNTIME FABRIC - AMERICAS: US | CANADA
 | xref:runtime-fabric::index.adoc[Runtime Fabric] | n/a | Planned | Available a| Contact your account manager to unlock this capability. For more information, refer to:
 
 * xref:runtime-fabric::install-self-managed-network-configuration.adoc[Configuring Your Network to Support Runtime Fabric]
@@ -195,6 +229,7 @@ Americas::
 * xref:runtime-fabric::install-helm.adoc[Installing Runtime Fabric Using Helm]
 * xref:runtime-fabric::use-anypoint-monitoring.adoc[Using Anypoint Monitoring]
 
+//USAGE REPORTS - AMERICAS: US | CANADA
 | xref:general::usage-reports.adoc[Usage Reports] | n/a | Planned | Available | n/a
 |===
 --
@@ -206,14 +241,17 @@ Europe::
 |===
 |Component |Feature Description |EU Cloud |Notes
 
+//ACCESS MANAGEMENT - EUROPE: EU
 .4+| xref:access-management::index.adoc[Access Management] | All other features | Planned .4+| n/a
 | Audit Logging | Planned
 | Business Groups | Planned
 | External Identity Management Integration | Planned
 
+//AGENT VISUALIZER - EUROPE: EU
 .2+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Planned .2+| n/a
 | Links to logs and traces | Planned
 
+//API MANAGER - EUROPE: EU
 .6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned .6+a| n/a
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
@@ -223,15 +261,18 @@ Europe::
 | API Manager 2.x | Planned
 | API Console Proxy/Trusted Domains | Planned
 
+//CLI - EUROPE: EU
 .2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Planned .2+| n/a
 | API Catalog CLI | Planned
 
+//CODE BUILDER - EUROPE: EU
 .5+| xref:anypoint-code-builder::index.adoc[Anypoint Code Builder] | All other features | Planned .5+| For details, refer to xref:anypoint-code-builder::index.adoc#us-eu-clouds[Anypoint Code Builder Cloud Hosts]
 | Agent Network Projects (Agent Broker) | Planned
 | MuleSoft Vibes | Planned
 | Generative Data Transformations | Planned
 | Generative MUnit | Planned
 
+//EXCHANGE - EUROPE: EU
 .5+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Planned .5+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
 | AI Documentation Generation | Planned
 | Amazon Cloud Front | Planned
@@ -245,16 +286,17 @@ Europe::
 //MONITORING - EUROPE: EU
 | Basic Alerts | Planned
 | Basic Monitoring | Available
-| Hybrid Standalone Mule (HSA) Enabled | Planned
-| Standard Dashboards (Anypoint Insights) | Available
 | Custom Dashboards | Available
-| Traces Beta | Available
-| Telemetry Exporter | Available
+| Hybrid Standalone Mule (HSA) Enabled | Planned
+| Integration Intelligence | Planned
 | Log Search | Available
 | Log Tailing | Planned
 | Reports | Available
-| Integration Intelligence | Planned
+| Standard Dashboards (Anypoint Insights) | Available
+| Telemetry Exporter | Available
+| Traces Beta | Available
 
+//MQ - EUROPE: EU
 .18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Planned .18+a| For details, refer to:
 
 * xref:mq::index.adoc#mq-features-control-plane[Anypoint MQ Features by Control Plane]
@@ -278,38 +320,52 @@ Europe::
 | Usage Charts (Access Management) | Not planned
 | Usage Reports (Usage) | Planned
 
+//PARTNER MANAGER - EUROPE: EU
 .2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Planned .2+| n/a
 | Generative B2B Message Summary Feature | Planned
 
+//PRIVATE CLOUD EDITION - EUROPE: EU
 | xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
+//RUNTIME MANAGER - EUROPE: EU
 .3+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Planned .3+| n/a
 | Insights | Not planned
 | Monitoring for Hybrid Standalone Deployments | Planned
 
+//SECURITY SECRETS MANAGER - EUROPE: EU
 | xref:anypoint-security::index-secrets-manager.adoc[Anypoint Security Secrets Manager] | n/a | Planned | n/a
 
+//STUDIO - EUROPE: EU
 | xref:studio::index.adoc[Anypoint Studio] | n/a | Planned | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
 
+//API VISUALIZER - EUROPE: EU
 .3+| xref:visualizer::index.adoc[API Visualizer] | Architecture | Planned .3+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
 | Policies | Planned
 | Troubleshooting | Planned
 
+//API COMMUNITY MANAGER - EUROPE: EU
 | xref:api-community-manager::index.adoc[API Community Manager] | n/a | Planned | n/a
 
+//API DESIGNER - EUROPE: EU
 | xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Planned | n/a
 
+//API EXPERIENCE HUB - EUROPE: EU
 | xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Planned | n/a
 
+//API FUNCTIONAL MONITORING - EUROPE: EU
 | xref:api-functional-monitoring::index.adoc[API Functional Monitoring] | n/a | Planned | n/a
 
+//API GOVERNANCE - EUROPE: EU
 | xref:api-governance::index.adoc[API Governance] | n/a | Planned | n/a
 
+//API MOCKING SERVICE - EUROPE: EU
 | xref:design-center::design-mocking-service.adoc[API Mocking Service] | n/a | Planned | n/a
 
+//CLOUDHUB - EUROPE: EU
 .2+| xref:cloudhub::index.adoc[CloudHub] | All other features | Planned .2+| n/a
 | Global CloudHub Deployment | Planned
 
+//CLOUDHUB 2.0 - EUROPE: EU
 .6+| xref:cloudhub-2::index.adoc[CloudHub 2.0] | All other features | Planned .6+a| For details, refer to:
 
 * xref:cloudhub-2::index.adoc#cloudhub2-hyperforce[CloudHub 2.0 Features by Control Plane]
@@ -320,31 +376,42 @@ Europe::
 | Private Space - VPN | Planned
 | Shared Spaces | Planned
 
+//CONNECTORS - EUROPE: EU
 | xref:connectors::index.adoc[Connectors] |  | Planned | 
 
+//DATAWEAVE - EUROPE: EU
 | xref:dataweave::index.adoc[DataWeave] | n/a | Planned | n/a
 
+//DATALOADER - EUROPE: EU
 | Dataloader | n/a | Not planned | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
 
+//ENHANCED MULESOFT EXPERIENCE AND REMOTE MCP SERVER - EUROPE: EU
 | xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Planned | n/a
 
+//OMNI GATEWAY - EUROPE: EU
 .4+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned .4+| n/a
 | Managed Omni Gateway on Runtime Fabric | Planned
 | Self-Managed - Connected Mode | Planned
 | Self-Managed - Local Mode | Planned
 
+//HYBRID STANDALONE DEPLOYMENT - EUROPE: EU
 | xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | n/a
 
+//IDP - EUROPE: EU
 | xref:idp::index.adoc[IDP] | n/a | Planned | n/a
 
+//MULE GATEWAY - EUROPE: EU
 .2+| xref:gateway-home::index.adoc#anypoint_mule_gateway[Mule Gateway] | Mule Gateway Proxies | Planned .2+| n/a
 | Mule Gateway Policies | Planned
 
+//MULE RUNTIME ENGINE - EUROPE: EU
 .2+| xref:mule-runtime::index.adoc[Mule runtime engine] | All features | Planned .2+| Mule 3 is not supported as it reached EOL.
 | Diagnostics Agent | Planned
 
+//MUNIT - EUROPE: EU
 | xref:munit::index.adoc[MUnit] | All features | Planned | n/a
 
+//OBJECT STORE V2 - EUROPE: EU
 .6+| xref:object-store::index.adoc[Object Store V2] | All other features | Planned .6+a| For details, refer to:
 
 * xref:object-store::index.adoc#os-features-control-plane[Object Store Features by Control Plane]
@@ -355,8 +422,10 @@ Europe::
 | Usage Reports (Usage) | Planned
 | Usage Charts (Access Management) | Not planned
 
+//RPA - EUROPE: EU
 | xref:rpa-home::index.adoc[RPA] | n/a | Planned | n/a
 
+//RUNTIME FABRIC - EUROPE: EU
 | xref:runtime-fabric::index.adoc[Runtime Fabric] | n/a | Planned a| Contact your account manager to unlock this capability. For more information, refer to:
 
 * xref:runtime-fabric::install-self-managed-network-configuration.adoc[Configuring Your Network to Support Runtime Fabric]
@@ -364,6 +433,7 @@ Europe::
 * xref:runtime-fabric::install-helm.adoc[Installing Runtime Fabric Using Helm]
 * xref:runtime-fabric::use-anypoint-monitoring.adoc[Using Anypoint Monitoring]
 
+//USAGE REPORTS - EUROPE: EU
 | xref:general::usage-reports.adoc[Usage Reports] | n/a | Planned | n/a
 |===
 --
@@ -375,14 +445,17 @@ Asia Pacific::
 |===
 |Component |Feature Description |Japan Cloud |India Cloud |Notes
 
+//ACCESS MANAGEMENT - ASIA: JA | INDIA
 .4+| xref:access-management::index.adoc[Access Management] | All other features | Available | Available .4+| n/a
 | Audit Logging | Available | Available
 | Business Groups | Available | Available
 | External Identity Management Integration | Available | Available
 
+//AGENT VISUALIZER - ASIA: JA | INDIA
 .2+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Available | Available .2+| n/a
 | Links to logs and traces | Planned | Available
 
+//API MANAGER - ASIA: JA | INDIA
 .6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available .6+a| n/a
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
@@ -392,15 +465,18 @@ Asia Pacific::
 | API Manager 2.x | Available | Available
 | API Console Proxy/Trusted Domains | Planned | Available
 
+//CLI - ASIA: JA | INDIA
 .2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Available | Available .2+| n/a
 | API Catalog CLI | Available | Available
 
+//CODE BUILDER - ASIA: JA | INDIA
 .5+| xref:anypoint-code-builder::index.adoc[Anypoint Code Builder] | All other features | Available | Availabl .5+| For details, refer to xref:anypoint-code-builder::index.adoc#us-eu-clouds[Anypoint Code Builder Cloud Hosts]
 | Agent Network Projects (Agent Broker) | Available | Available
 | MuleSoft Vibes | Available | Available
 | Generative Data Transformations | Available | Available
 | Generative MUnit | Available | Available
 
+//EXCHANGE - ASIA: JA | INDIA
 .5+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Available | Available .5+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
 | AI Documentation Generation | Available | Available
 | Amazon Cloud Front | Planned | Available
@@ -414,16 +490,17 @@ Asia Pacific::
 //MONITORING - ASIA: JA | INDIA
 | Basic Alerts | Planned | Available
 | Basic Monitoring | Available | Available
-| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned
-| Standard Dashboards (Anypoint Insights) | Available | Available
 | Custom Dashboards | Planned | Planned
-| Traces Beta | Not planned | Not planned
-| Telemetry Exporter | Available | Available
-| Log Search | Available (Beta) | Available
-| Log Tailing | Available | Available
+| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned
 | Integration Intelligence | Available | Available
+| Log Search | Planned | Available
+| Log Tailing | Available | Available
 | Reports | Available | Available
+| Standard Dashboards (Anypoint Insights) | Available | Available
+| Telemetry Exporter | Available | Available
+| Traces Beta | Not planned | Not planned
 
+//MQ - ASIA: JA | INDIA
 .18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Available | Available .18+a| For details, refer to:
 
 * xref:mq::index.adoc#mq-features-control-plane[Anypoint MQ Features by Control Plane]
@@ -447,38 +524,52 @@ Asia Pacific::
 | Usage Charts (Access Management) | Not planned | Not planned
 | Usage Reports (Usage) | Available | Available
 
+//PARTNER MANAGER - ASIA: JA | INDIA
 .2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Available | Planned .2+| n/a
 | Generative B2B Message Summary Feature | Available | Planned
 
+//PRIVATE CLOUD EDITION - ASIA: JA | INDIA
 | xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
+//RUNTIME MANAGER - ASIA: JA | INDIA
 .3+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Available | Available .3+| n/a
 | Insights | Not planned | Not planned
 | Monitoring for Hybrid Standalone Deployments | Not planned | Not planned
 
+//SECURITY SECRETS MANAGER - ASIA: JA | INDIA
 | xref:anypoint-security::index-secrets-manager.adoc[Anypoint Security Secrets Manager] | n/a | Available | Available | n/a
 
+//STUDIO - ASIA: JA | INDIA
 | xref:studio::index.adoc[Anypoint Studio] | n/a | Available | Available | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
 
+//API VISUALIZER - ASIA: JA | INDIA
 .3+| xref:visualizer::index.adoc[API Visualizer] | Architecture | Available | Planned .3+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
 | Policies | Available | Available
 | Troubleshooting | Planned | Planned
 
+//API COMMUNITY MANAGER - ASIA: JA | INDIA
 | xref:api-community-manager::index.adoc[API Community Manager] | n/a | Available | Not planned | n/a
 
+//API DESIGNER - ASIA: JA | INDIA
 | xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Not planned | Not planned | n/a
 
+//API EXPERIENCE HUB - ASIA: JA | INDIA
 | xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Available | Not planned | n/a
 
+//API FUNCTIONAL MONITORING - ASIA: JA | INDIA
 | xref:api-functional-monitoring::index.adoc[API Functional Monitoring] | n/a | Available | Available | n/a
 
+//API GOVERNANCE - ASIA: JA | INDIA
 | xref:api-governance::index.adoc[API Governance] | n/a | Available | Available | n/a
 
+//API MOCKING SERVICE - ASIA: JA | INDIA
 | xref:design-center::design-mocking-service.adoc[API Mocking Service] | n/a | Available | Available | n/a
 
+//CLOUDHUB - ASIA: JA | INDIA
 .2+| xref:cloudhub::index.adoc[CloudHub] | All other features | Not planned | Not planned .2+| n/a
 | Global CloudHub Deployment | Not planned | Not planned
 
+//CLOUDHUB 2.0 - ASIA: JA | INDIA
 .6+| xref:cloudhub-2::index.adoc[CloudHub 2.0] | All other features | Available | Available .6+a| For details, refer to:
 
 * xref:cloudhub-2::index.adoc#cloudhub2-hyperforce[CloudHub 2.0 Features by Control Plane]
@@ -489,31 +580,42 @@ Asia Pacific::
 | Private Space - VPN | Available | Available
 | Shared Spaces | Available | Available
 
+//CONNECTORS - ASIA: JA | INDIA
 | xref:connectors::index.adoc[Connectors] |  | Available | Available | 
 
+//DATAWEAVE - ASIA: JA | INDIA
 | xref:dataweave::index.adoc[DataWeave] | n/a | Available | Available | n/a
 
+//DATALOADER - ASIA: JA | INDIA
 | Dataloader | n/a | Not planned | Not planned | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
 
+//ENHANCED MULESOFT EXPERIENCE AND REMOTE MCP SERVER - ASIA: JA | INDIA
 | xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | Planned | n/a
 
+//OMNI GATEWAY - ASIA: JA | INDIA
 .4+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Available | Available .4+| n/a
 | Managed Omni Gateway on Runtime Fabric | Available | Available
 | Self-Managed - Connected Mode | Available | Available
 | Self-Managed - Local Mode | Available | Available
 
+//HYBRID STANDALONE DEPLOYMENT - ASIA: JA | INDIA
 | xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | Planned | n/a
 
+//IDP - ASIA: JA | INDIA
 | xref:idp::index.adoc[IDP] | n/a | Not planned | Not planned | n/a
 
+//MULE GATEWAY - ASIA: JA | INDIA
 .2+| xref:gateway-home::index.adoc#anypoint_mule_gateway[Mule Gateway] | Mule Gateway Proxies | Available | Available .2+| n/a
 | Mule Gateway Policies | Available | Available
 
+//MULE RUNTIME ENGINE - ASIA: JA | INDIA
 .2+| xref:mule-runtime::index.adoc[Mule runtime engine] | All features | Available | Available .2+| Mule 3 is not supported as it reached EOL.
 | Diagnostics Agent | Available | Available
 
+//MUNIT - ASIA: JA | INDIA
 | xref:munit::index.adoc[MUnit] | All features | Available | Available | n/a
 
+//OBJECT STORE V2 - ASIA: JA | INDIA
 .6+| xref:object-store::index.adoc[Object Store V2] | All other features | Available | Available .6+a| For details, refer to:
 
 * xref:object-store::index.adoc#os-features-control-plane[Object Store Features by Control Plane]
@@ -524,8 +626,10 @@ Asia Pacific::
 | Usage Reports (Usage) | Available | Available
 | Usage Charts (Access Management) | Not planned | Not planned
 
+//RPA - ASIA: JA | INDIA
 | xref:rpa-home::index.adoc[RPA] | n/a | Not planned | Not planned | n/a
 
+//RUNTIME FABRIC - ASIA: JA | INDIA
 | xref:runtime-fabric::index.adoc[Runtime Fabric] | n/a | Available | Available a| Contact your account manager to unlock this capability. For more information, refer to:
 
 * xref:runtime-fabric::install-self-managed-network-configuration.adoc[Configuring Your Network to Support Runtime Fabric]
@@ -533,6 +637,7 @@ Asia Pacific::
 * xref:runtime-fabric::install-helm.adoc[Installing Runtime Fabric Using Helm]
 * xref:runtime-fabric::use-anypoint-monitoring.adoc[Using Anypoint Monitoring]
 
+//USAGE REPORTS - ASIA: JA | INDIA
 | xref:general::usage-reports.adoc[Usage Reports] | n/a | Available | Available | n/a
 |===
 --

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -76,7 +76,7 @@ Americas::
 | Agent Scanners | Planned | Available
 
 //MONITORING - AMERICAS: US | CANADA
-.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .12+a| For details, refer to:
+.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .13+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 //MONITORING - AMERICAS: US | CANADA
@@ -87,6 +87,7 @@ Americas::
 | Integration Intelligence | Planned | Available
 | Log Search | Available | Available (Beta)
 | Log Tailing | Planned | Available
+| Logs Raw Data | Planned | Planned
 | Reports | Available | Available
 | Standard Dashboards (Anypoint Insights) | Available | Available
 | Telemetry Exporter | Available | Available
@@ -280,7 +281,7 @@ Europe::
 | Agent Scanners | Planned
 
 //MONITORING - EUROPE: EU
-.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned .12+a| For details, refer to:
+.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned .13+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 //MONITORING - EUROPE: EU
@@ -291,6 +292,7 @@ Europe::
 | Integration Intelligence | Planned
 | Log Search | Available
 | Log Tailing | Planned
+| Logs Raw Data | Planned
 | Reports | Available
 | Standard Dashboards (Anypoint Insights) | Available
 | Telemetry Exporter | Available
@@ -484,7 +486,7 @@ Asia Pacific::
 | Agent Scanners | Available | Available
 
 //MONITORING - ASIA: JA | INDIA
-.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .12+a| For details, refer to:
+.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .13+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 //MONITORING - ASIA: JA | INDIA
@@ -495,6 +497,7 @@ Asia Pacific::
 | Integration Intelligence | Available | Available
 | Log Search | Planned | Available
 | Log Tailing | Available | Available
+| Logs Raw Data | Planned | Available
 | Reports | Available | Available
 | Standard Dashboards (Anypoint Insights) | Available | Available
 | Telemetry Exporter | Available | Available

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -45,9 +45,7 @@ Americas::
 .2+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Planned | Available .2+| n/a
 | Links to logs and traces | Planned | Planned
 
-.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned | Available .6+a| For details, refer to:
-
-* xref:api-manager::latest-overview-concept.adoc#APIM-hyperforce[API Manager Features by Control Plane]
+.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned | Available .6+a| n/a
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
 | API Analytics | Not planned | Not planned
@@ -216,9 +214,7 @@ Europe::
 .2+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Planned .2+| n/a
 | Links to logs and traces | Planned
 
-.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned .6+a| For details, refer to:
-
-* xref:api-manager::latest-overview-concept.adoc#APIM-hyperforce[API Manager Features by Control Plane]
+.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned .6+a| n/a
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
 | API Analytics | Not planned
@@ -387,9 +383,7 @@ Asia Pacific::
 .2+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Available | Available .2+| n/a
 | Links to logs and traces | Planned | Available
 
-.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available .6+a| For details, refer to:
-
-* xref:api-manager::latest-overview-concept.adoc#APIM-hyperforce[API Manager Features by Control Plane]
+.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available .6+a| n/a
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
 | API Analytics | Not planned | Not planned
@@ -428,7 +422,7 @@ Asia Pacific::
 | Log Search | Available (Beta) | Available
 | Log Tailing | Available | Available
 | Integration Intelligence | Available | Available
-| Reports | Planned | Available
+| Reports | Available | Available
 
 .18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Available | Available .18+a| For details, refer to:
 

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -110,7 +110,7 @@ Americas::
 | Usage Reports (Usage) | Planned | Available
 
 .2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Planned | Available .2+| n/a
-| Generative B2B Message Summary Feature | Planned | Planned
+| Generative B2B Message Summary Feature | Planned | Available
 
 | xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
@@ -448,7 +448,7 @@ Asia Pacific::
 | Usage Reports (Usage) | Available | Available
 
 .2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Available | Planned .2+| n/a
-| Generative B2B Message Summary Feature | Planned | Planned
+| Generative B2B Message Summary Feature | Available | Planned
 
 | xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 


### PR DESCRIPTION
## Summary
- Simplify the Anypoint API Manager notes to `n/a` across the Americas, Europe, and Asia Pacific tabs (removed the "API Manager Features by Control Plane" reference link).
- Set the **Reports** (Anypoint Monitoring) status to `Available` for **Japan Cloud** in the Asia Pacific tab.

## Test plan
- [ ] Verify the rendered Hyperforce overview page tables display correctly.
- [ ] Confirm Reports shows Available for Japan Cloud, Canada Cloud, and India Cloud.

Made with [Cursor](https://cursor.com)