### PR TITLE
@W-21465269: Fix incorrect private DNS IP visibility claim in networking guide

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-networking-guide.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-networking-guide.adoc
@@ -102,7 +102,9 @@ Traffic egressing to the internet originates from an IP address listed under the
 
 The public DNS target and the private DNS target IPs also don't change during the lifetime of the private space.
 
-The private DNS target uses private static IP addresses. These IP addresses remain constant throughout the lifetime of the private space. This makes them suitable for use in internal DNS configurations or allowlists in your connected external networks. You can view the private DNS target IP addresses in the *Inbound IP Addresses* section of the private space network configuration.
+The private DNS target uses private static IP addresses. These IP addresses remain constant throughout the lifetime of the private space. This makes them suitable for use in internal DNS configurations or allowlists in your connected external networks.
+
+You can view the public DNS target IP addresses in the *Inbound IP Addresses* section of the private space network configuration.
 
 Traffic egressing to a VPN or Transit Gateway (TGW) originates from the private space CIDR block.
 


### PR DESCRIPTION
## Summary

- Corrects an inaccurate statement in the **IP Ranges** section of `ch2-networking-guide.adoc`
- The original text claimed that private DNS target IP addresses are viewable in the *Inbound IP Addresses* section of the private space network configuration
- In reality, only **public** DNS target IP addresses are shown there; private DNS target IPs are not surfaced in the UI
- Updated the sentence to accurately state that public DNS target IP addresses are shown in that section

## Related

GUS: W-21465269

## Test plan

- [ ] Verify the updated sentence reads correctly on the rendered docs page
- [ ] Confirm no other references to "private DNS target IP addresses" in the UI still claim they are visible in the Inbound IP Addresses section