### PR TITLE
W-23365932-hyperforce-australia-cloud-hosting-kt

### DIFF
--- a/hosting-home/modules/ROOT/pages/index.adoc
+++ b/hosting-home/modules/ROOT/pages/index.adoc
@@ -53,6 +53,12 @@ MuleSoft provides cloud-managed and self-hosted control plane options. This tabl
 | MuleSoft-managed control plane hosted in India. See xref:hyperforce::index.adoc#deploy-mule-apps-to-control-planes[Deploy Mule Apps to Control Planes].
 | Indian data residency
 
+| Australia Cloud
+| `au1.platform.mulesoft.com`
+| Australia
+| MuleSoft-managed control plane hosted in Australia. See xref:hyperforce::index.adoc#deploy-mule-apps-to-control-planes[Deploy Mule Apps to Control Planes].
+| Australian data residency
+
 | MuleSoft Government Cloud
 | `gov.anypoint.mulesoft.com`
 | United States
@@ -100,6 +106,9 @@ This table lists the runtime regions available for each control plane:
 
 | https://in1.platform.mulesoft.com[India Cloud]
 | Asia Pacific | India (Mumbai) | `ap-south-1`
+
+| https://au1.platform.mulesoft.com[Australia Cloud]
+| Asia Pacific | Australia (Sydney) | `ap-southeast-2`
 
 | https://gov.anypoint.mulesoft.com[MuleSoft Government Cloud]
 | US Government | US GovCloud (West) | `us-gov-west`


### PR DESCRIPTION
## Summary

- Adds Australia Cloud (`au1.platform.mulesoft.com`, Sydney) to the control plane options table
- Adds Australia Cloud to the runtime regions table (Asia Pacific | Australia (Sydney) | `ap-southeast-2`)
- Follows the same pattern established by the India Cloud addition in PR #425

> **Note:** The region name `ap-southeast-2` is TBD — update before publishing if a different region name is confirmed.

## Test plan

- [ ] Confirm region name for Australia Cloud with the team before publishing
- [ ] Verify the platform URL `au1.platform.mulesoft.com` is correct