### PR TITLE
W-23365932-hyperforce-australia-cloud-features-kt

### DIFF
--- a/hyperforce/modules/ROOT/pages/configure-mule-hyperforce.adoc
+++ b/hyperforce/modules/ROOT/pages/configure-mule-hyperforce.adoc
@@ -17,6 +17,7 @@ To configure Mule in the `wrapper.conf` file, modify these properties, replacing
 * `ca1.platform.mulesoft.com`
 * `jp1.platform.mulesoft.com`
 * `in1.platform.mulesoft.com`
+* `au1.platform.mulesoft.com`
 
 This example shows the `wrapper.conf` file configuration for Canada Cloud (`ca1.platform.mulesoft.com`): 
 
@@ -34,6 +35,7 @@ To configure Mule properties via the command line, use the following options whe
 * `ca1.platform.mulesoft.com`
 * `jp1.platform.mulesoft.com`
 * `in1.platform.mulesoft.com`
+* `au1.platform.mulesoft.com`
 
 This example shows the properties configuration for EU Cloud `eu1.anypoint.mulesoft.com` via the command like:
  
@@ -51,6 +53,7 @@ When deploying to CloudHub 2.0, in the *Properties* tab of Anypoint Runtime Mana
 * `ca1.platform.mulesoft.com`
 * `jp1.platform.mulesoft.com`
 * `in1.platform.mulesoft.com`
+* `au1.platform.mulesoft.com`
 
 This example shows the properties configuration for Japan Cloud `jp1.platform.mulesoft.com` :
 

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -288,7 +288,7 @@ Europe::
 | Basic Alerts | Available
 | Basic Monitoring | Available
 | Custom Dashboards | Available
-| Hybrid Standalone Mule (HSA) Enabled | Planned
+| Hybrid Standalone Mule (HSA) Enabled | Available
 | Integration Intelligence | Available
 | Log Search | Available
 | Logs Raw Data | Available

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -288,7 +288,7 @@ Europe::
 | Basic Alerts | Available
 | Basic Monitoring | Available
 | Custom Dashboards | Available
-| Hybrid Standalone Mule (HSA) Enabled | Available
+| Hybrid Standalone Mule (HSA) Enabled | Planned
 | Integration Intelligence | Available
 | Log Search | Available
 | Logs Raw Data | Available
@@ -496,7 +496,7 @@ Asia Pacific::
 | Basic Alerts | Available | Available | Available
 | Basic Monitoring | Available | Available | Available
 | Custom Dashboards | Planned | Planned | Planned
-| Hybrid Standalone Mule (HSA) Enabled | Available | Available | Planned
+| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Planned
 | Integration Intelligence | Available | Available | Available
 | Log Search | Available | Available | Available
 | Logs Raw Data | Available | Available | Available

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -496,7 +496,7 @@ Asia Pacific::
 | Basic Alerts | Available | Available | Available
 | Basic Monitoring | Available | Available | Available
 | Custom Dashboards | Planned | Planned | Planned
-| Hybrid Standalone Mule (HSA) Enabled | Available | Available | Available
+| Hybrid Standalone Mule (HSA) Enabled | Available | Available | Planned
 | Integration Intelligence | Available | Available | Available
 | Log Search | Available | Available | Available
 | Logs Raw Data | Available | Available | Available

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -48,7 +48,7 @@ Americas::
 | Links to logs and traces | Planned | Planned
 
 //API MANAGER - AMERICAS: US | CANADA
-.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned | Available .6+a| n/a
+.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned | Available .6+a| For details, refer to:
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
 | API Analytics | Not planned | Not planned
@@ -256,7 +256,7 @@ Europe::
 | Links to logs and traces | Planned
 
 //API MANAGER - EUROPE: EU
-.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned .6+a| n/a
+.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned .6+a| For details, refer to:   
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
 | API Analytics | Not planned
@@ -464,7 +464,7 @@ Asia Pacific::
 | Links to traces | Planned | Planned | Planned
 
 //API MANAGER - ASIA: JA | INDIA | AU
-.7+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available | Available .7+a| n/a
+.7+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available | Available .7+a| For details, refer to:
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
 | API Analytics | Not planned | Not planned | Not planned

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -495,7 +495,7 @@ Asia Pacific::
 | Basic Monitoring | Available | Available | Available
 | Custom Dashboards | Planned | Planned | Planned
 | Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Available
-| Integration Intelligence | Available | Available | Planned
+| Integration Intelligence | Available | Available | Available
 | Log Search | Available | Available | Available
 | Logs Raw Data | Available | Available | Available
 | Reports | Available | Available | Available

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -379,7 +379,7 @@ Europe::
 | Shared Spaces | Planned
 
 //CONNECTORS - EUROPE: EU
-| xref:connectors::index.adoc[Connectors] |  | Planned | 
+| xref:connectors::index.adoc[Connectors] |  | Planned |
 
 //DATAWEAVE - EUROPE: EU
 | xref:dataweave::index.adoc[DataWeave] | n/a | Planned | n/a
@@ -454,8 +454,9 @@ Asia Pacific::
 | External Identity Management Integration | Available | Available | Available
 
 //AGENT VISUALIZER - ASIA: JA | INDIA | AU
-.2+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Available | Available | Available .2+| n/a
-| Links to logs and traces | Planned | Available | Available
+.3+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Available | Available | Available .3+| n/a
+| Links to logs | Available | Available | Available
+| Links to traces | Planned | Planned | Planned
 
 //API MANAGER - ASIA: JA | INDIA | AU
 .7+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available | Available .7+a| n/a
@@ -466,7 +467,7 @@ Asia Pacific::
 | API Manager 1.x | Not planned | Not planned | Not planned
 | API Manager 2.x | Available | Available | Available
 | API Console Proxy/Trusted Domains | Planned | Available | Available
-| Key Metrics | Planned | Available | Planned
+| Key Metrics | Not planned | Not planned | Not planned
 
 //CLI - ASIA: JA | INDIA | AU
 .2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Available | Available | Available .2+| n/a
@@ -480,10 +481,11 @@ Asia Pacific::
 | Generative MUnit | Available | Available | Available
 
 //EXCHANGE - ASIA: JA | INDIA | AU
-.5+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Available | Available | Available .5+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
+.6+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Available | Available | Available .6+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
 | AI Documentation Generation | Available | Available | Available
-| Amazon Cloud Front | Planned | Available | Planned
+| Amazon Cloud Front | Planned | Planned | Planned
 | Agent, MCP, and LLM assets (Agent Registry) | Available | Available | Available
+| Public MCP Servers in Agent Registry | Available | Available | Available
 | Agent Scanners | Available | Available | Available
 
 //MONITORING - ASIA: JA | INDIA | AU
@@ -537,7 +539,7 @@ Asia Pacific::
 //RUNTIME MANAGER - ASIA: JA | INDIA | AU
 .4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Available | Available | Available .4+| n/a
 | Insights | Not planned | Not planned | Not planned
-| Log Tailing | Available | Available | Available
+| Log Tailing | Available | Available | Planned
 | Monitoring for Hybrid Standalone Deployments | Not planned | Not planned | Not planned
 
 //SECURITY SECRETS MANAGER - ASIA: JA | INDIA | AU
@@ -547,9 +549,8 @@ Asia Pacific::
 | xref:studio::index.adoc[Anypoint Studio] | n/a | Available | Available | Available | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
 
 //API VISUALIZER - ASIA: JA | INDIA | AU
-.3+| xref:visualizer::index.adoc[API Visualizer] | Architecture | Available | Available | Planned .3+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
-| Policies | Available | Available | Planned
-| Troubleshooting | Planned | Planned | Planned
+.2+| xref:visualizer::index.adoc[API Visualizer] | Architecture and Policies View | Available | Available | Planned .2+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
+| Troubleshooting View | Planned | Planned | Planned
 
 //API COMMUNITY MANAGER - ASIA: JA | INDIA | AU
 | xref:api-community-manager::index.adoc[API Community Manager] | n/a | Available | Not planned | Not planned | n/a
@@ -558,7 +559,7 @@ Asia Pacific::
 | xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Not planned | Not planned | Not planned | n/a
 
 //API EXPERIENCE HUB - ASIA: JA | INDIA | AU
-| xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Available | Not planned | Planned | n/a
+| xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Available | Planned | Planned | n/a
 
 //API FUNCTIONAL MONITORING - ASIA: JA | INDIA | AU
 | xref:api-functional-monitoring::index.adoc[API Functional Monitoring] | n/a | Available | Available | Available | n/a
@@ -597,10 +598,13 @@ Asia Pacific::
 | xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | Available | Available | n/a
 
 //OMNI GATEWAY - ASIA: JA | INDIA | AU
-.4+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Available | Available | Available .4+| n/a
+.7+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Available | Available | Available .7+| n/a
 | Managed Omni Gateway on Runtime Fabric | Available | Available | Available
 | Self-Managed - Connected Mode | Available | Available | Available
 | Self-Managed - Local Mode | Available | Available | Available
+| A2A Governance (Policies) | Available | Available | Planned
+| MCP Governance (Policies) | Available | Available | Planned
+| LLM Gateway | Available | Available | Available
 
 //HYBRID STANDALONE DEPLOYMENT - ASIA: JA | INDIA | AU
 | xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | Planned | Available | n/a
@@ -613,7 +617,8 @@ Asia Pacific::
 | Mule Gateway Policies | Available | Available | Available
 
 //MULE RUNTIME ENGINE - ASIA: JA | INDIA | AU
-.2+| xref:mule-runtime::index.adoc[Mule runtime engine] | All features | Available | Available | Available .2+| Mule 3 is not supported as it reached EOL.
+.3+| xref:mule-runtime::index.adoc[Mule runtime engine] | All features | Available | Available | Available .3+| Mule 3 is not supported as it reached EOL.
+| Direct Telemetry Stream | Available | Available | Available
 | Diagnostics Agent | Available | Available | Available
 
 //MUNIT - ASIA: JA | INDIA | AU

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -186,10 +186,13 @@ Americas::
 | xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Planned | Available | n/a
 
 //OMNI GATEWAY - AMERICAS: US | CANADA
-.4+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned | Available .4+| n/a
+.7+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned | Available .4+| n/a
 | Managed Omni Gateway on Runtime Fabric | Planned | Available
 | Self-Managed - Connected Mode | Planned | Available
 | Self-Managed - Local Mode | Planned | Available
+| A2A Governance (Policies) | Available | Available 
+| MCP Governance (Policies) | Available | Available 
+| LLM Gateway | Available | Available 
 
 //HYBRID STANDALONE DEPLOYMENT - AMERICAS: US | CANADA
 | xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | Planned | n/a
@@ -391,10 +394,12 @@ Europe::
 | xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Planned | n/a
 
 //OMNI GATEWAY - EUROPE: EU
-.4+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned .4+| n/a
+.7+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned .4+| n/a
 | Managed Omni Gateway on Runtime Fabric | Planned
 | Self-Managed - Connected Mode | Planned
 | Self-Managed - Local Mode | Planned
+| A2A Governance (Policies) | Available 
+| LLM Gateway | Available
 
 //HYBRID STANDALONE DEPLOYMENT - EUROPE: EU
 | xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | n/a
@@ -549,7 +554,7 @@ Asia Pacific::
 | xref:studio::index.adoc[Anypoint Studio] | n/a | Available | Available | Available | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
 
 //API VISUALIZER - ASIA: JA | INDIA | AU
-.2+| xref:visualizer::index.adoc[API Visualizer] | Architecture and Policies View | Available | Available | Planned .2+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
+.2+| xref:visualizer::index.adoc[API Visualizer] | Architecture and Policies View | Available | Available | Available .2+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
 | Troubleshooting View | Planned | Planned | Planned
 
 //API COMMUNITY MANAGER - ASIA: JA | INDIA | AU

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -76,7 +76,7 @@ Americas::
 | Agent Scanners | Planned | Available
 
 //MONITORING - AMERICAS: US | CANADA
-.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .13+a| For details, refer to:
+.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .12+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 //MONITORING - AMERICAS: US | CANADA
@@ -86,7 +86,6 @@ Americas::
 | Hybrid Standalone Mule (HSA) Enabled | Planned | Planned
 | Integration Intelligence | Available | Available
 | Log Search | Available | Available
-| Log Tailing | Planned | Available
 | Logs Raw Data | Planned | Available
 | Reports | Available | Available
 | Standard Dashboards (Anypoint Insights) | Available | Available
@@ -125,8 +124,9 @@ Americas::
 | xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
 //RUNTIME MANAGER - AMERICAS: US | CANADA
-.3+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Planned | Available .3+| n/a
+.4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Planned | Available .4+| n/a
 | Insights | Not planned | Not planned
+| Log Tailing | Planned | Available
 | Monitoring for Hybrid Standalone Deployments | Planned | Not planned
 
 //SECURITY SECRETS MANAGER - AMERICAS: US | CANADA
@@ -281,7 +281,7 @@ Europe::
 | Agent Scanners | Planned
 
 //MONITORING - EUROPE: EU
-.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned .13+a| For details, refer to:
+.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned .12+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 //MONITORING - EUROPE: EU
@@ -291,7 +291,6 @@ Europe::
 | Hybrid Standalone Mule (HSA) Enabled | Planned
 | Integration Intelligence | Available
 | Log Search | Planned
-| Log Tailing | Planned
 | Logs Raw Data | Planned
 | Reports | Available
 | Standard Dashboards (Anypoint Insights) | Available
@@ -330,8 +329,9 @@ Europe::
 | xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
 //RUNTIME MANAGER - EUROPE: EU
-.3+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Planned .3+| n/a
+.4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Planned .4+| n/a
 | Insights | Not planned
+| Log Tailing | Planned
 | Monitoring for Hybrid Standalone Deployments | Planned
 
 //SECURITY SECRETS MANAGER - EUROPE: EU
@@ -487,7 +487,7 @@ Asia Pacific::
 | Agent Scanners | Available | Available | Available
 
 //MONITORING - ASIA: JA | INDIA | AU
-.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned | Planned .13+a| For details, refer to:
+.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned | Planned .12+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 //MONITORING - ASIA: JA | INDIA | AU
@@ -497,7 +497,6 @@ Asia Pacific::
 | Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Available
 | Integration Intelligence | Available | Available | Planned
 | Log Search | Available | Available | Available
-| Log Tailing | Available | Available | Available
 | Logs Raw Data | Available | Available | Available
 | Reports | Available | Available | Available
 | Standard Dashboards (Anypoint Insights) | Available | Available | Available
@@ -536,8 +535,9 @@ Asia Pacific::
 | xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Available | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
 //RUNTIME MANAGER - ASIA: JA | INDIA | AU
-.3+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Available | Available | Available .3+| n/a
+.4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Available | Available | Available .4+| n/a
 | Insights | Not planned | Not planned | Not planned
+| Log Tailing | Available | Available | Available
 | Monitoring for Hybrid Standalone Deployments | Not planned | Not planned | Not planned
 
 //SECURITY SECRETS MANAGER - ASIA: JA | INDIA | AU

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -501,7 +501,7 @@ Asia Pacific::
 | Basic Alerts | Available | Available | Available
 | Basic Monitoring | Available | Available | Available
 | Custom Dashboards | Planned | Planned | Planned
-| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Planned
+| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Available
 | Integration Intelligence | Available | Available | Available
 | Log Search | Available | Available | Available
 | Logs Raw Data | Available | Available | Available

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -126,7 +126,7 @@ Americas::
 //RUNTIME MANAGER - AMERICAS: US | CANADA
 .4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Planned | Available .4+| n/a
 | Insights | Not planned | Not planned
-| Log Tailing | Planned | Available
+| Log Tailing | Available | Available
 | Monitoring for Hybrid Standalone Deployments | Planned | Not planned
 
 //SECURITY SECRETS MANAGER - AMERICAS: US | CANADA
@@ -331,7 +331,7 @@ Europe::
 //RUNTIME MANAGER - EUROPE: EU
 .4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Planned .4+| n/a
 | Insights | Not planned
-| Log Tailing | Planned
+| Log Tailing | Available
 | Monitoring for Hybrid Standalone Deployments | Planned
 
 //SECURITY SECRETS MANAGER - EUROPE: EU

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -281,7 +281,7 @@ Europe::
 | Agent Scanners | Planned
 
 //MONITORING - EUROPE: EU
-.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned .12+a| For details, refer to:
+.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Available .12+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 //MONITORING - EUROPE: EU

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -494,7 +494,7 @@ Asia Pacific::
 | Basic Alerts | Available | Available | Available
 | Basic Monitoring | Available | Available | Available
 | Custom Dashboards | Planned | Planned | Planned
-| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Planned
+| Hybrid Standalone Mule (HSA) Enabled | Available | Available | Available
 | Integration Intelligence | Available | Available | Available
 | Log Search | Available | Available | Available
 | Logs Raw Data | Available | Available | Available

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -332,7 +332,7 @@ Europe::
 .4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Planned .4+| n/a
 | Insights | Not planned
 | Log Tailing | Available
-| Monitoring for Hybrid Standalone Deployments | Planned
+| Monitoring for Hybrid Standalone Deployments | Available
 
 //SECURITY SECRETS MANAGER - EUROPE: EU
 | xref:anypoint-security::index-secrets-manager.adoc[Anypoint Security Secrets Manager] | n/a | Planned | n/a

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -494,7 +494,7 @@ Asia Pacific::
 | Basic Alerts | Available | Available | Available
 | Basic Monitoring | Available | Available | Available
 | Custom Dashboards | Planned | Planned | Planned
-| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Available
+| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Planned
 | Integration Intelligence | Available | Available | Available
 | Log Search | Available | Available | Available
 | Logs Raw Data | Available | Available | Available

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -501,7 +501,7 @@ Asia Pacific::
 | Reports | Available | Available | Available
 | Standard Dashboards (Anypoint Insights) | Available | Available | Available
 | Telemetry Exporter | Available | Available | Available
-| Traces Beta | Not planned | Not planned | Planned
+| Traces Beta | Not planned | Not planned | Not Planned
 
 //MQ - ASIA: JA | INDIA | AU
 .18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Available | Available | Available .18+a| For details, refer to:

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -594,7 +594,7 @@ Asia Pacific::
 | Dataloader | n/a | Not planned | Not planned | Not planned | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
 
 //ENHANCED MULESOFT EXPERIENCE AND REMOTE MCP SERVER - ASIA: JA | INDIA | AU
-| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | Available | Planned | n/a
+| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | Available | Available | n/a
 
 //OMNI GATEWAY - ASIA: JA | INDIA | AU
 .4+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Available | Available | Available .4+| n/a

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -458,14 +458,15 @@ Asia Pacific::
 | Links to logs and traces | Planned | Available | Available
 
 //API MANAGER - ASIA: JA | INDIA | AU
-.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available | Available .6+a| n/a
+.7+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available | Available .7+a| n/a
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
-| API Analytics | Not planned | Not planned | Available
+| API Analytics | Not planned | Not planned | Not planned
 | API Alerts | Planned | Available | Available
-| API Manager 1.x | Not planned | Not planned | Available
+| API Manager 1.x | Not planned | Not planned | Not planned
 | API Manager 2.x | Available | Available | Available
 | API Console Proxy/Trusted Domains | Planned | Available | Available
+| Key Metrics | Planned | Available | Planned
 
 //CLI - ASIA: JA | INDIA | AU
 .2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Available | Available | Available .2+| n/a
@@ -481,27 +482,27 @@ Asia Pacific::
 //EXCHANGE - ASIA: JA | INDIA | AU
 .5+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Available | Available | Available .5+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
 | AI Documentation Generation | Available | Available | Available
-| Amazon Cloud Front | Planned | Available | Available
+| Amazon Cloud Front | Planned | Available | Planned
 | Agent, MCP, and LLM assets (Agent Registry) | Available | Available | Available
 | Agent Scanners | Available | Available | Available
 
 //MONITORING - ASIA: JA | INDIA | AU
-.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned | Available .13+a| For details, refer to:
+.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned | Planned .13+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 //MONITORING - ASIA: JA | INDIA | AU
 | Basic Alerts | Available | Available | Available
 | Basic Monitoring | Available | Available | Available
-| Custom Dashboards | Planned | Planned | Available
+| Custom Dashboards | Planned | Planned | Planned
 | Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Available
-| Integration Intelligence | Available | Available | Available
+| Integration Intelligence | Available | Available | Planned
 | Log Search | Available | Available | Available
 | Log Tailing | Available | Available | Available
 | Logs Raw Data | Available | Available | Available
 | Reports | Available | Available | Available
 | Standard Dashboards (Anypoint Insights) | Available | Available | Available
 | Telemetry Exporter | Available | Available | Available
-| Traces Beta | Not planned | Not planned | Available
+| Traces Beta | Not planned | Not planned | Planned
 
 //MQ - ASIA: JA | INDIA | AU
 .18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Available | Available | Available .18+a| For details, refer to:
@@ -511,33 +512,33 @@ Asia Pacific::
 * xref:mq::mq-faq.adoc#mq-hyperforce[Anypoint MQ Available Regions]
 | Anypoint MQ Admin API | Available | Available | Available
 | Anypoint MQ Broker API | Available | Available | Available
-| Anypoint MQ Connector earlier than 4.x | Not planned | Not planned | Available
+| Anypoint MQ Connector earlier than 4.x | Not planned | Not planned | Not planned
 | Anypoint MQ Connector versions 4.x and later | Available | Available | Available
 | Anypoint MQ Stats API (Anypont MQ Stats only) | Available | Available | Available
-| Anypoint MQ Stats API (Usage Metrics) | Not planned | Not planned | Available
-| Client Apps | Not planned | Not planned | Available
-| CloudHub 1.0 Deployments | Not planned | Not planned | Available
+| Anypoint MQ Stats API (Usage Metrics) | Not planned | Not planned | Not planned
+| Client Apps | Not planned | Not planned | Not planned
+| CloudHub 1.0 Deployments | Not planned | Not planned | Not planned
 | Connected Apps | Available | Available | Available
-| Cross-Region Failover | Not planned | Not planned | Available
+| Cross-Region Failover | Not planned | Not planned | Not planned
 | Encrypted Queues | Available | Available | Available
 | FIFO Exchange | Available | Available | Available
 | Message Exchanges | Available | Available | Available
 | Message Routing | Available | Available | Available
-| Unencrypted Queues | Not planned | Not planned | Available
-| Usage Charts (Access Management) | Not planned | Not planned | Available
+| Unencrypted Queues | Not planned | Not planned | Not planned
+| Usage Charts (Access Management) | Not planned | Not planned | Not planned
 | Usage Reports (Usage) | Available | Available | Available
 
 //PARTNER MANAGER - ASIA: JA | INDIA | AU
-.2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Available | Planned | Available .2+| n/a
-| Generative B2B Message Summary Feature | Available | Planned | Available
+.2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Available | Planned | Planned .2+| n/a
+| Generative B2B Message Summary Feature | Available | Planned | Planned
 
 //PRIVATE CLOUD EDITION - ASIA: JA | INDIA | AU
 | xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Available | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
 //RUNTIME MANAGER - ASIA: JA | INDIA | AU
 .3+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Available | Available | Available .3+| n/a
-| Insights | Not planned | Not planned | Available
-| Monitoring for Hybrid Standalone Deployments | Not planned | Not planned | Available
+| Insights | Not planned | Not planned | Not planned
+| Monitoring for Hybrid Standalone Deployments | Not planned | Not planned | Not planned
 
 //SECURITY SECRETS MANAGER - ASIA: JA | INDIA | AU
 | xref:anypoint-security::index-secrets-manager.adoc[Anypoint Security Secrets Manager] | n/a | Available | Available | Available | n/a
@@ -546,18 +547,18 @@ Asia Pacific::
 | xref:studio::index.adoc[Anypoint Studio] | n/a | Available | Available | Available | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
 
 //API VISUALIZER - ASIA: JA | INDIA | AU
-.3+| xref:visualizer::index.adoc[API Visualizer] | Architecture | Available | Available | Available .3+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
-| Policies | Available | Available | Available
-| Troubleshooting | Planned | Planned | Available
+.3+| xref:visualizer::index.adoc[API Visualizer] | Architecture | Available | Available | Planned .3+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
+| Policies | Available | Available | Planned
+| Troubleshooting | Planned | Planned | Planned
 
 //API COMMUNITY MANAGER - ASIA: JA | INDIA | AU
-| xref:api-community-manager::index.adoc[API Community Manager] | n/a | Available | Not planned | Available | n/a
+| xref:api-community-manager::index.adoc[API Community Manager] | n/a | Available | Not planned | Not planned | n/a
 
 //API DESIGNER - ASIA: JA | INDIA | AU
-| xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Not planned | Not planned | Available | n/a
+| xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Not planned | Not planned | Not planned | n/a
 
 //API EXPERIENCE HUB - ASIA: JA | INDIA | AU
-| xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Available | Not planned | Available | n/a
+| xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Available | Not planned | Planned | n/a
 
 //API FUNCTIONAL MONITORING - ASIA: JA | INDIA | AU
 | xref:api-functional-monitoring::index.adoc[API Functional Monitoring] | n/a | Available | Available | Available | n/a
@@ -569,8 +570,8 @@ Asia Pacific::
 | xref:design-center::design-mocking-service.adoc[API Mocking Service] | n/a | Available | Available | Available | n/a
 
 //CLOUDHUB - ASIA: JA | INDIA | AU
-.2+| xref:cloudhub::index.adoc[CloudHub] | All other features | Not planned | Not planned | Available .2+| n/a
-| Global CloudHub Deployment | Not planned | Not planned | Available
+.2+| xref:cloudhub::index.adoc[CloudHub] | All other features | Not planned | Not planned | Not planned .2+| n/a
+| Global CloudHub Deployment | Not planned | Not planned | Not planned
 
 //CLOUDHUB 2.0 - ASIA: JA | INDIA | AU
 .6+| xref:cloudhub-2::index.adoc[CloudHub 2.0] | All other features | Available | Available | Available .6+a| For details, refer to:
@@ -578,7 +579,7 @@ Asia Pacific::
 * xref:cloudhub-2::index.adoc#cloudhub2-hyperforce[CloudHub 2.0 Features by Control Plane]
 * xref:cloudhub-2::ch2-architecture.adoc#regions-and-dns-records[Runtime Plane Regions and DNS Records]
 | Deleting the Default Egress Route | Available | Available | Available
-| Global Cloud Deployment | Not planned | Not planned | Available
+| Global Cloud Deployment | Not planned | Not planned | Not planned
 | Private Space | Available | Available | Available
 | Private Space - VPN | Available | Available | Available
 | Shared Spaces | Available | Available | Available
@@ -590,10 +591,10 @@ Asia Pacific::
 | xref:dataweave::index.adoc[DataWeave] | n/a | Available | Available | Available | n/a
 
 //DATALOADER - ASIA: JA | INDIA | AU
-| Dataloader | n/a | Not planned | Not planned | Available | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
+| Dataloader | n/a | Not planned | Not planned | Not planned | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
 
 //ENHANCED MULESOFT EXPERIENCE AND REMOTE MCP SERVER - ASIA: JA | INDIA | AU
-| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | Planned | Available | n/a
+| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | Planned | Planned | n/a
 
 //OMNI GATEWAY - ASIA: JA | INDIA | AU
 .4+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Available | Available | Available .4+| n/a
@@ -605,7 +606,7 @@ Asia Pacific::
 | xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | Planned | Available | n/a
 
 //IDP - ASIA: JA | INDIA | AU
-| xref:idp::index.adoc[IDP] | n/a | Not planned | Not planned | Available | n/a
+| xref:idp::index.adoc[IDP] | n/a | Not planned | Not planned | Not planned | n/a
 
 //MULE GATEWAY - ASIA: JA | INDIA | AU
 .2+| xref:gateway-home::index.adoc#anypoint_mule_gateway[Mule Gateway] | Mule Gateway Proxies | Available | Available | Available .2+| n/a
@@ -624,13 +625,13 @@ Asia Pacific::
 * xref:object-store::index.adoc#os-features-control-plane[Object Store Features by Control Plane]
 * xref:object-store::osv2-faq.adoc#osv2-regions[Object Store v2 Regions]
 | Connected Apps | Available | Available | Available
-| CloudHub 1.0 Deployments | Not planned | No planned | Available
-| Object Store v2 Stats API | Not planned | Not planned | Available
+| CloudHub 1.0 Deployments | Not planned | No planned | Not planned
+| Object Store v2 Stats API | Not planned | Not planned | Not planned
 | Usage Reports (Usage) | Available | Available | Available
-| Usage Charts (Access Management) | Not planned | Not planned | Available
+| Usage Charts (Access Management) | Not planned | Not planned | Not planned
 
 //RPA - ASIA: JA | INDIA | AU
-| xref:rpa-home::index.adoc[RPA] | n/a | Not planned | Not planned | Available | n/a
+| xref:rpa-home::index.adoc[RPA] | n/a | Not planned | Not planned | Not planned | n/a
 
 //RUNTIME FABRIC - ASIA: JA | INDIA | AU
 | xref:runtime-fabric::index.adoc[Runtime Fabric] | n/a | Available | Available | Available a| Contact your account manager to unlock this capability. For more information, refer to:

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -443,205 +443,205 @@ Europe::
 Asia Pacific::
 +
 --
-[%header%autowidth.spread,cols=".^a,.^a,.^a,.^a,.^a"]
+[%header%autowidth.spread,cols=".^a,.^a,.^a,.^a,.^a,.^a"]
 |===
-|Component |Feature Description |Japan Cloud |India Cloud |Notes
+|Component |Feature Description |Japan Cloud |India Cloud |Australia Cloud |Notes
 
-//ACCESS MANAGEMENT - ASIA: JA | INDIA
-.4+| xref:access-management::index.adoc[Access Management] | All other features | Available | Available .4+| n/a
-| Audit Logging | Available | Available
-| Business Groups | Available | Available
-| External Identity Management Integration | Available | Available
+//ACCESS MANAGEMENT - ASIA: JA | INDIA | AU
+.4+| xref:access-management::index.adoc[Access Management] | All other features | Available | Available | Available .4+| n/a
+| Audit Logging | Available | Available | Available
+| Business Groups | Available | Available | Available
+| External Identity Management Integration | Available | Available | Available
 
-//AGENT VISUALIZER - ASIA: JA | INDIA
-.2+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Available | Available .2+| n/a
-| Links to logs and traces | Planned | Available
+//AGENT VISUALIZER - ASIA: JA | INDIA | AU
+.2+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Available | Available | Available .2+| n/a
+| Links to logs and traces | Planned | Available | Available
 
-//API MANAGER - ASIA: JA | INDIA
-.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available .6+a| n/a
+//API MANAGER - ASIA: JA | INDIA | AU
+.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available | Available .6+a| n/a
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
-| API Analytics | Not planned | Not planned
-| API Alerts | Planned | Available
-| API Manager 1.x | Not planned | Not planned
-| API Manager 2.x | Available | Available
-| API Console Proxy/Trusted Domains | Planned | Available
+| API Analytics | Not planned | Not planned | Available
+| API Alerts | Planned | Available | Available
+| API Manager 1.x | Not planned | Not planned | Available
+| API Manager 2.x | Available | Available | Available
+| API Console Proxy/Trusted Domains | Planned | Available | Available
 
-//CLI - ASIA: JA | INDIA
-.2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Available | Available .2+| n/a
-| API Catalog CLI | Available | Available
+//CLI - ASIA: JA | INDIA | AU
+.2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Available | Available | Available .2+| n/a
+| API Catalog CLI | Available | Available | Available
 
-//CODE BUILDER - ASIA: JA | INDIA
-.5+| xref:anypoint-code-builder::index.adoc[Anypoint Code Builder] | All other features | Available | Availabl .5+| For details, refer to xref:anypoint-code-builder::index.adoc#us-eu-clouds[Anypoint Code Builder Cloud Hosts]
-| Agent Network Projects (Agent Broker) | Available | Available
-| MuleSoft Vibes | Available | Available
-| Generative Data Transformations | Available | Available
-| Generative MUnit | Available | Available
+//CODE BUILDER - ASIA: JA | INDIA | AU
+.5+| xref:anypoint-code-builder::index.adoc[Anypoint Code Builder] | All other features | Available | Available | Available .5+| For details, refer to xref:anypoint-code-builder::index.adoc#us-eu-clouds[Anypoint Code Builder Cloud Hosts]
+| Agent Network Projects (Agent Broker) | Available | Available | Available
+| MuleSoft Vibes | Available | Available | Available
+| Generative Data Transformations | Available | Available | Available
+| Generative MUnit | Available | Available | Available
 
-//EXCHANGE - ASIA: JA | INDIA
-.5+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Available | Available .5+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
-| AI Documentation Generation | Available | Available
-| Amazon Cloud Front | Planned | Available
-| Agent, MCP, and LLM assets (Agent Registry) | Available | Available
-| Agent Scanners | Available | Available
+//EXCHANGE - ASIA: JA | INDIA | AU
+.5+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Available | Available | Available .5+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
+| AI Documentation Generation | Available | Available | Available
+| Amazon Cloud Front | Planned | Available | Available
+| Agent, MCP, and LLM assets (Agent Registry) | Available | Available | Available
+| Agent Scanners | Available | Available | Available
 
-//MONITORING - ASIA: JA | INDIA
-.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .13+a| For details, refer to:
+//MONITORING - ASIA: JA | INDIA | AU
+.13+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned | Available .13+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
-//MONITORING - ASIA: JA | INDIA
-| Basic Alerts | Available | Available
-| Basic Monitoring | Available | Available
-| Custom Dashboards | Planned | Planned
-| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned
-| Integration Intelligence | Available | Available
-| Log Search | Available | Available
-| Log Tailing | Available | Available
-| Logs Raw Data | Available | Available
-| Reports | Available | Available
-| Standard Dashboards (Anypoint Insights) | Available | Available
-| Telemetry Exporter | Available | Available
-| Traces Beta | Not planned | Not planned
+//MONITORING - ASIA: JA | INDIA | AU
+| Basic Alerts | Available | Available | Available
+| Basic Monitoring | Available | Available | Available
+| Custom Dashboards | Planned | Planned | Available
+| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Available
+| Integration Intelligence | Available | Available | Available
+| Log Search | Available | Available | Available
+| Log Tailing | Available | Available | Available
+| Logs Raw Data | Available | Available | Available
+| Reports | Available | Available | Available
+| Standard Dashboards (Anypoint Insights) | Available | Available | Available
+| Telemetry Exporter | Available | Available | Available
+| Traces Beta | Not planned | Not planned | Available
 
-//MQ - ASIA: JA | INDIA
-.18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Available | Available .18+a| For details, refer to:
+//MQ - ASIA: JA | INDIA | AU
+.18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Available | Available | Available .18+a| For details, refer to:
 
 * xref:mq::index.adoc#mq-features-control-plane[Anypoint MQ Features by Control Plane]
 * xref:mq::index.adoc#mq-on-hyperforce[Limitations by Control Plane]
 * xref:mq::mq-faq.adoc#mq-hyperforce[Anypoint MQ Available Regions]
-| Anypoint MQ Admin API | Available | Available
-| Anypoint MQ Broker API | Available | Available
-| Anypoint MQ Connector earlier than 4.x | Not planned | Not planned
-| Anypoint MQ Connector versions 4.x and later | Available | Available
-| Anypoint MQ Stats API (Anypont MQ Stats only) | Available | Available
-| Anypoint MQ Stats API (Usage Metrics) | Not planned | Not planned
-| Client Apps | Not planned | Not planned
-| CloudHub 1.0 Deployments | Not planned | Not planned
-| Connected Apps | Available | Available
-| Cross-Region Failover | Not planned | Not planned
-| Encrypted Queues | Available | Available
-| FIFO Exchange | Available | Available
-| Message Exchanges | Available | Available
-| Message Routing | Available | Available
-| Unencrypted Queues | Not planned | Not planned
-| Usage Charts (Access Management) | Not planned | Not planned
-| Usage Reports (Usage) | Available | Available
+| Anypoint MQ Admin API | Available | Available | Available
+| Anypoint MQ Broker API | Available | Available | Available
+| Anypoint MQ Connector earlier than 4.x | Not planned | Not planned | Available
+| Anypoint MQ Connector versions 4.x and later | Available | Available | Available
+| Anypoint MQ Stats API (Anypont MQ Stats only) | Available | Available | Available
+| Anypoint MQ Stats API (Usage Metrics) | Not planned | Not planned | Available
+| Client Apps | Not planned | Not planned | Available
+| CloudHub 1.0 Deployments | Not planned | Not planned | Available
+| Connected Apps | Available | Available | Available
+| Cross-Region Failover | Not planned | Not planned | Available
+| Encrypted Queues | Available | Available | Available
+| FIFO Exchange | Available | Available | Available
+| Message Exchanges | Available | Available | Available
+| Message Routing | Available | Available | Available
+| Unencrypted Queues | Not planned | Not planned | Available
+| Usage Charts (Access Management) | Not planned | Not planned | Available
+| Usage Reports (Usage) | Available | Available | Available
 
-//PARTNER MANAGER - ASIA: JA | INDIA
-.2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Available | Planned .2+| n/a
-| Generative B2B Message Summary Feature | Available | Planned
+//PARTNER MANAGER - ASIA: JA | INDIA | AU
+.2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Available | Planned | Available .2+| n/a
+| Generative B2B Message Summary Feature | Available | Planned | Available
 
-//PRIVATE CLOUD EDITION - ASIA: JA | INDIA
-| xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
+//PRIVATE CLOUD EDITION - ASIA: JA | INDIA | AU
+| xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Available | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
-//RUNTIME MANAGER - ASIA: JA | INDIA
-.3+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Available | Available .3+| n/a
-| Insights | Not planned | Not planned
-| Monitoring for Hybrid Standalone Deployments | Not planned | Not planned
+//RUNTIME MANAGER - ASIA: JA | INDIA | AU
+.3+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Available | Available | Available .3+| n/a
+| Insights | Not planned | Not planned | Available
+| Monitoring for Hybrid Standalone Deployments | Not planned | Not planned | Available
 
-//SECURITY SECRETS MANAGER - ASIA: JA | INDIA
-| xref:anypoint-security::index-secrets-manager.adoc[Anypoint Security Secrets Manager] | n/a | Available | Available | n/a
+//SECURITY SECRETS MANAGER - ASIA: JA | INDIA | AU
+| xref:anypoint-security::index-secrets-manager.adoc[Anypoint Security Secrets Manager] | n/a | Available | Available | Available | n/a
 
-//STUDIO - ASIA: JA | INDIA
-| xref:studio::index.adoc[Anypoint Studio] | n/a | Available | Available | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
+//STUDIO - ASIA: JA | INDIA | AU
+| xref:studio::index.adoc[Anypoint Studio] | n/a | Available | Available | Available | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
 
-//API VISUALIZER - ASIA: JA | INDIA
-.3+| xref:visualizer::index.adoc[API Visualizer] | Architecture | Available | Available .3+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
-| Policies | Available | Available
-| Troubleshooting | Planned | Planned
+//API VISUALIZER - ASIA: JA | INDIA | AU
+.3+| xref:visualizer::index.adoc[API Visualizer] | Architecture | Available | Available | Available .3+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
+| Policies | Available | Available | Available
+| Troubleshooting | Planned | Planned | Available
 
-//API COMMUNITY MANAGER - ASIA: JA | INDIA
-| xref:api-community-manager::index.adoc[API Community Manager] | n/a | Available | Not planned | n/a
+//API COMMUNITY MANAGER - ASIA: JA | INDIA | AU
+| xref:api-community-manager::index.adoc[API Community Manager] | n/a | Available | Not planned | Available | n/a
 
-//API DESIGNER - ASIA: JA | INDIA
-| xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Not planned | Not planned | n/a
+//API DESIGNER - ASIA: JA | INDIA | AU
+| xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Not planned | Not planned | Available | n/a
 
-//API EXPERIENCE HUB - ASIA: JA | INDIA
-| xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Available | Not planned | n/a
+//API EXPERIENCE HUB - ASIA: JA | INDIA | AU
+| xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Available | Not planned | Available | n/a
 
-//API FUNCTIONAL MONITORING - ASIA: JA | INDIA
-| xref:api-functional-monitoring::index.adoc[API Functional Monitoring] | n/a | Available | Available | n/a
+//API FUNCTIONAL MONITORING - ASIA: JA | INDIA | AU
+| xref:api-functional-monitoring::index.adoc[API Functional Monitoring] | n/a | Available | Available | Available | n/a
 
-//API GOVERNANCE - ASIA: JA | INDIA
-| xref:api-governance::index.adoc[API Governance] | n/a | Available | Available | n/a
+//API GOVERNANCE - ASIA: JA | INDIA | AU
+| xref:api-governance::index.adoc[API Governance] | n/a | Available | Available | Available | n/a
 
-//API MOCKING SERVICE - ASIA: JA | INDIA
-| xref:design-center::design-mocking-service.adoc[API Mocking Service] | n/a | Available | Available | n/a
+//API MOCKING SERVICE - ASIA: JA | INDIA | AU
+| xref:design-center::design-mocking-service.adoc[API Mocking Service] | n/a | Available | Available | Available | n/a
 
-//CLOUDHUB - ASIA: JA | INDIA
-.2+| xref:cloudhub::index.adoc[CloudHub] | All other features | Not planned | Not planned .2+| n/a
-| Global CloudHub Deployment | Not planned | Not planned
+//CLOUDHUB - ASIA: JA | INDIA | AU
+.2+| xref:cloudhub::index.adoc[CloudHub] | All other features | Not planned | Not planned | Available .2+| n/a
+| Global CloudHub Deployment | Not planned | Not planned | Available
 
-//CLOUDHUB 2.0 - ASIA: JA | INDIA
-.6+| xref:cloudhub-2::index.adoc[CloudHub 2.0] | All other features | Available | Available .6+a| For details, refer to:
+//CLOUDHUB 2.0 - ASIA: JA | INDIA | AU
+.6+| xref:cloudhub-2::index.adoc[CloudHub 2.0] | All other features | Available | Available | Available .6+a| For details, refer to:
 
 * xref:cloudhub-2::index.adoc#cloudhub2-hyperforce[CloudHub 2.0 Features by Control Plane]
 * xref:cloudhub-2::ch2-architecture.adoc#regions-and-dns-records[Runtime Plane Regions and DNS Records]
-| Deleting the Default Egress Route | Available | Available
-| Global Cloud Deployment | Not planned | Not planned
-| Private Space | Available | Available
-| Private Space - VPN | Available | Available
-| Shared Spaces | Available | Available
+| Deleting the Default Egress Route | Available | Available | Available
+| Global Cloud Deployment | Not planned | Not planned | Available
+| Private Space | Available | Available | Available
+| Private Space - VPN | Available | Available | Available
+| Shared Spaces | Available | Available | Available
 
-//CONNECTORS - ASIA: JA | INDIA
-| xref:connectors::index.adoc[Connectors] |  | Available | Available | 
+//CONNECTORS - ASIA: JA | INDIA | AU
+| xref:connectors::index.adoc[Connectors] |  | Available | Available | Available |
 
-//DATAWEAVE - ASIA: JA | INDIA
-| xref:dataweave::index.adoc[DataWeave] | n/a | Available | Available | n/a
+//DATAWEAVE - ASIA: JA | INDIA | AU
+| xref:dataweave::index.adoc[DataWeave] | n/a | Available | Available | Available | n/a
 
-//DATALOADER - ASIA: JA | INDIA
-| Dataloader | n/a | Not planned | Not planned | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
+//DATALOADER - ASIA: JA | INDIA | AU
+| Dataloader | n/a | Not planned | Not planned | Available | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
 
-//ENHANCED MULESOFT EXPERIENCE AND REMOTE MCP SERVER - ASIA: JA | INDIA
-| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | Planned | n/a
+//ENHANCED MULESOFT EXPERIENCE AND REMOTE MCP SERVER - ASIA: JA | INDIA | AU
+| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | Planned | Available | n/a
 
-//OMNI GATEWAY - ASIA: JA | INDIA
-.4+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Available | Available .4+| n/a
-| Managed Omni Gateway on Runtime Fabric | Available | Available
-| Self-Managed - Connected Mode | Available | Available
-| Self-Managed - Local Mode | Available | Available
+//OMNI GATEWAY - ASIA: JA | INDIA | AU
+.4+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Available | Available | Available .4+| n/a
+| Managed Omni Gateway on Runtime Fabric | Available | Available | Available
+| Self-Managed - Connected Mode | Available | Available | Available
+| Self-Managed - Local Mode | Available | Available | Available
 
-//HYBRID STANDALONE DEPLOYMENT - ASIA: JA | INDIA
-| xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | Planned | n/a
+//HYBRID STANDALONE DEPLOYMENT - ASIA: JA | INDIA | AU
+| xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | Planned | Available | n/a
 
-//IDP - ASIA: JA | INDIA
-| xref:idp::index.adoc[IDP] | n/a | Not planned | Not planned | n/a
+//IDP - ASIA: JA | INDIA | AU
+| xref:idp::index.adoc[IDP] | n/a | Not planned | Not planned | Available | n/a
 
-//MULE GATEWAY - ASIA: JA | INDIA
-.2+| xref:gateway-home::index.adoc#anypoint_mule_gateway[Mule Gateway] | Mule Gateway Proxies | Available | Available .2+| n/a
-| Mule Gateway Policies | Available | Available
+//MULE GATEWAY - ASIA: JA | INDIA | AU
+.2+| xref:gateway-home::index.adoc#anypoint_mule_gateway[Mule Gateway] | Mule Gateway Proxies | Available | Available | Available .2+| n/a
+| Mule Gateway Policies | Available | Available | Available
 
-//MULE RUNTIME ENGINE - ASIA: JA | INDIA
-.2+| xref:mule-runtime::index.adoc[Mule runtime engine] | All features | Available | Available .2+| Mule 3 is not supported as it reached EOL.
-| Diagnostics Agent | Available | Available
+//MULE RUNTIME ENGINE - ASIA: JA | INDIA | AU
+.2+| xref:mule-runtime::index.adoc[Mule runtime engine] | All features | Available | Available | Available .2+| Mule 3 is not supported as it reached EOL.
+| Diagnostics Agent | Available | Available | Available
 
-//MUNIT - ASIA: JA | INDIA
-| xref:munit::index.adoc[MUnit] | All features | Available | Available | n/a
+//MUNIT - ASIA: JA | INDIA | AU
+| xref:munit::index.adoc[MUnit] | All features | Available | Available | Available | n/a
 
-//OBJECT STORE V2 - ASIA: JA | INDIA
-.6+| xref:object-store::index.adoc[Object Store V2] | All other features | Available | Available .6+a| For details, refer to:
+//OBJECT STORE V2 - ASIA: JA | INDIA | AU
+.6+| xref:object-store::index.adoc[Object Store V2] | All other features | Available | Available | Available .6+a| For details, refer to:
 
 * xref:object-store::index.adoc#os-features-control-plane[Object Store Features by Control Plane]
 * xref:object-store::osv2-faq.adoc#osv2-regions[Object Store v2 Regions]
-| Connected Apps | Available | Available
-| CloudHub 1.0 Deployments | Not planned | No planned
-| Object Store v2 Stats API | Not planned | Not planned
-| Usage Reports (Usage) | Available | Available
-| Usage Charts (Access Management) | Not planned | Not planned
+| Connected Apps | Available | Available | Available
+| CloudHub 1.0 Deployments | Not planned | No planned | Available
+| Object Store v2 Stats API | Not planned | Not planned | Available
+| Usage Reports (Usage) | Available | Available | Available
+| Usage Charts (Access Management) | Not planned | Not planned | Available
 
-//RPA - ASIA: JA | INDIA
-| xref:rpa-home::index.adoc[RPA] | n/a | Not planned | Not planned | n/a
+//RPA - ASIA: JA | INDIA | AU
+| xref:rpa-home::index.adoc[RPA] | n/a | Not planned | Not planned | Available | n/a
 
-//RUNTIME FABRIC - ASIA: JA | INDIA
-| xref:runtime-fabric::index.adoc[Runtime Fabric] | n/a | Available | Available a| Contact your account manager to unlock this capability. For more information, refer to:
+//RUNTIME FABRIC - ASIA: JA | INDIA | AU
+| xref:runtime-fabric::index.adoc[Runtime Fabric] | n/a | Available | Available | Available a| Contact your account manager to unlock this capability. For more information, refer to:
 
 * xref:runtime-fabric::install-self-managed-network-configuration.adoc[Configuring Your Network to Support Runtime Fabric]
 * xref:runtime-fabric::configure-local-registry.adoc[Using a Local Registry with Runtime Fabric]
 * xref:runtime-fabric::install-helm.adoc[Installing Runtime Fabric Using Helm]
 * xref:runtime-fabric::use-anypoint-monitoring.adoc[Using Anypoint Monitoring]
 
-//USAGE REPORTS - ASIA: JA | INDIA
-| xref:general::usage-reports.adoc[Usage Reports] | n/a | Available | Available | n/a
+//USAGE REPORTS - ASIA: JA | INDIA | AU
+| xref:general::usage-reports.adoc[Usage Reports] | n/a | Available | Available | Available | n/a
 |===
 --
 ====
@@ -671,6 +671,9 @@ This table indicates the available and planned cloud regions for Hyperforce:
 
 | https://in1.platform.mulesoft.com[India Cloud]
 | Asia Pacific | `in1.platform.mulesoft.com` | Available
+
+| https://au1.platform.mulesoft.com[Australia Cloud]
+| Asia Pacific | `au1.platform.mulesoft.com` | Available
 |===
 
 == Mule Runtime Version Compatibility

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -76,7 +76,7 @@ Americas::
 | Agent Scanners | Planned | Available
 
 //MONITORING - AMERICAS: US | CANADA
-.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Planned | Planned .12+a| For details, refer to:
+.12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Available | Planned .12+a| For details, refer to:
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 //MONITORING - AMERICAS: US | CANADA
@@ -86,7 +86,7 @@ Americas::
 | Hybrid Standalone Mule (HSA) Enabled | Planned | Planned
 | Integration Intelligence | Available | Available
 | Log Search | Available | Available
-| Logs Raw Data | Planned | Available
+| Logs Raw Data | Available | Available
 | Reports | Available | Available
 | Standard Dashboards (Anypoint Insights) | Available | Available
 | Telemetry Exporter | Available | Available
@@ -285,13 +285,13 @@ Europe::
 
 * xref:monitoring::index.adoc#features[Monitoring Features by Control Plane]
 //MONITORING - EUROPE: EU
-| Basic Alerts | Planned
+| Basic Alerts | Available
 | Basic Monitoring | Available
 | Custom Dashboards | Available
 | Hybrid Standalone Mule (HSA) Enabled | Planned
 | Integration Intelligence | Available
-| Log Search | Planned
-| Logs Raw Data | Planned
+| Log Search | Available
+| Logs Raw Data | Available
 | Reports | Available
 | Standard Dashboards (Anypoint Insights) | Available
 | Telemetry Exporter | Available

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -594,7 +594,7 @@ Asia Pacific::
 | Dataloader | n/a | Not planned | Not planned | Not planned | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
 
 //ENHANCED MULESOFT EXPERIENCE AND REMOTE MCP SERVER - ASIA: JA | INDIA | AU
-| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | Planned | Planned | n/a
+| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | Available | Planned | n/a
 
 //OMNI GATEWAY - ASIA: JA | INDIA | AU
 .4+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Available | Available | Available .4+| n/a


### PR DESCRIPTION
## Summary

Mirrors the India Cloud additions from PR #416, adding Australia Cloud (`au1.platform.mulesoft.com`, Sydney) across the Hyperforce docs:

- **`hyperforce/modules/ROOT/pages/index.adoc`**:
  - Adds `Australia Cloud` column to the **Asia Pacific** tab in the feature support table, with all features set to `Available`
  - Adds Australia Cloud row to the **Control Plane Regions** table with status `Available`
- **`hyperforce/modules/ROOT/pages/configure-mule-hyperforce.adoc`**:
  - Adds `au1.platform.mulesoft.com` to the supported endpoint domain lists in all three configuration sections (wrapper.conf, command line, CloudHub 2.0)

## Test plan

- [ ] Verify all feature statuses for Australia Cloud are correct with the product team before publishing
- [ ] Confirm `au1.platform.mulesoft.com` is the correct platform URL