### PR TITLE
W-23365932: Add Australia Cloud to CloudHub 2.0 region tables

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/_partials/region-table-long.adoc
+++ b/cloudhub-2/modules/ROOT/pages/_partials/region-table-long.adoc
@@ -29,6 +29,9 @@
 | https://in1.platform.mulesoft.com[India Cloud]
 | Asia Pacific | India (Mumbai) | `ap-south-1` | `myapp-uniq-id.ind-w1.in1.cloudhub.io` | `<app>.internal-<space-id>.ind-w1.in1.cloudhub.io`
 
+| https://au1.platform.mulesoft.com[Australia Cloud]
+| Asia Pacific | Australia (Sydney) | `ap-southeast-2` | `myapp-uniq-id.aus-s1.au1.cloudhub.io` | `<app>.internal-<space-id>.aus-s1.au1.cloudhub.io`
+
 | https://gov.anypoint.mulesoft.com[MuleSoft Government Cloud]
 | US Government | US GovCloud (West) | `us-gov-west` | `myapp.usg-w1.gov.cloudhub.io` | -
 |===

--- a/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
@@ -165,6 +165,9 @@ The following table summarizes what DNS records are available for your applicati
 
 | https://in1.platform.mulesoft.com[India Cloud]
 | Asia Pacific | India (Mumbai) | ind-w1 | `cloudhub-ap-south-1` | `myapp-_uniq-id_._shard_.ind-w1.in1.cloudhub.io` | `Cloudhub-AP-South-1`
+
+| https://au1.platform.mulesoft.com[Australia Cloud]
+| Asia Pacific | Australia (Sydney) | aus-s1 | `cloudhub-ap-southeast-2` | `myapp-_uniq-id_._shard_.aus-s1.au1.cloudhub.io` | `Cloudhub-AP-Southeast-2`
 |===
 
 For example, if you deploy an application named `myapp` to Canada (Montreal), the domain used to access the application is `myapp-_uniq-id_._shard_.can-c1.cloudhub.io`.


### PR DESCRIPTION
## Summary

Replicates India Cloud changes from PR #424 for Australia Cloud (`au1.platform.mulesoft.com`).

- **`_partials/region-table-long.adoc`**: Added Australia Cloud row with region `ap-southeast-2`, DNS example `myapp-uniq-id.aus-s1.au1.cloudhub.io`, and internal DNS example `<app>.internal-<space-id>.aus-s1.au1.cloudhub.io`.
- **`ch2-architecture.adoc`**: Added Australia Cloud row to the DNS records table with shard prefix `aus-s1`, bucket `cloudhub-ap-southeast-2`, and DNS pattern `myapp-_uniq-id_._shard_.aus-s1.au1.cloudhub.io`.

## Notes

- DNS subdomain prefix `aus-s1` follows the existing US Cloud pattern for Australia (Sydney), extended with the `au1` control plane identifier.
- Region name `ap-southeast-2` aligns with the value used in the hosting overview.