### PR TITLE
W-23445516-ch2-log4j-external-collectors-kt

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-integrate-log-system.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-integrate-log-system.adoc
@@ -1,23 +1,24 @@
 = Integrating with Your Logging System Using Log4j
 
-You can integrate your CloudHub 2.0 application with your logging system using the Log4j configuration.
+You can stream Mule runtime logs, application logs, and tracing-module logs from CloudHub 2.0 to an external collector by configuring a custom asynchronous Log4j appender. This enables you to send logs to destinations such as Splunk, Azure Monitor, or any other external logging system that accepts Log4j output.
+
+[NOTE]
+External collectors such as Azure Monitor or a Telemetry Exporter are valid destinations for CloudHub 2.0 logs. These are reached as generic external collectors via a custom Log4j appender — they don't have a dedicated built-in connector in CloudHub 2.0.
 
 == Requirements and Restrictions
 
+* Log appenders must be asynchronous. Synchronous appenders aren't supported.
+* File appenders, such as FileAppender, RollingFileAppender, AnypointMonitoringFileAppender, and RandomAccessFileAppender, are removed automatically by the platform.
 * MuleSoft Support doesn't assist in implementing custom logging configurations or resolving issues caused by custom logging configurations.
-* MuleSoft is not responsible for issues arising from misconfiguration of your Log4j appender, including these or other issues:
+* MuleSoft isn't responsible for issues arising from misconfiguration of your Log4j appender, including these or other issues:
 ** Lost logging data
 ** Performance degradation
 ** Running out of disk space
-* Do not use synchronous log appenders.
-+
-You can use only asynchronous log appenders.
-* File appenders, such as FileAppender, RollingFileAppender, AnypointMonitoringFileAppender, and RandomAccessFileAppender, are removed automatically.
 * When using custom Log4j configurations, both Mule runtime engine and application logs remain available in Runtime Manager.
-* You can forward tracing module logs using only third-party appenders. You cannot update the logging patterns to send them to Anypoint Monitoring.
+* You can forward tracing module logs using only third-party appenders. You can't update the logging patterns to send them to Anypoint Monitoring.
 * Console logging is disabled by default in CloudHub 2.0. If you change log levels or appenders in a custom `log4j2.xml` and don't see the changes in the logs, use an appender that CloudHub 2.0 collects, such as a third-party appender that streams to your logging system. Log output from a Console appender alone doesn't appear in Runtime Manager.
 
-You can use any Log4j appender.
+You can use any asynchronous Log4j appender.
 
 For information about configuring `log4j2.xml`, see the
 https://logging.apache.org/log4j/2.x/manual/configuration.html#ConfigurationSyntax[Log4j Configuration Syntax^].

--- a/cloudhub-2/modules/ROOT/pages/ch2-integrate-log-system.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-integrate-log-system.adoc
@@ -8,7 +8,7 @@ External collectors such as Azure Monitor or a Telemetry Exporter are valid dest
 == Requirements and Restrictions
 
 * Log appenders must be asynchronous. Synchronous appenders aren't supported.
-* File appenders, such as FileAppender, RollingFileAppender, AnypointMonitoringFileAppender, and RandomAccessFileAppender, are removed automatically by the platform.
+* File appenders, such as `FileAppender`, `RollingFileAppender`, `AnypointMonitoringFileAppender`, and `RandomAccessFileAppender`, are removed automatically by the platform.
 * MuleSoft Support doesn't assist in implementing custom logging configurations or resolving issues caused by custom logging configurations.
 * MuleSoft isn't responsible for issues arising from misconfiguration of your Log4j appender, including these or other issues:
 ** Lost logging data

--- a/cloudhub-2/modules/ROOT/pages/ch2-integrate-log-system.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-integrate-log-system.adoc
@@ -3,7 +3,7 @@
 You can stream Mule runtime logs, application logs, and tracing-module logs from CloudHub 2.0 to an external collector by configuring a custom asynchronous Log4j appender. This enables you to send logs to destinations such as Splunk, Azure Monitor, or any other external logging system that accepts Log4j output.
 
 [NOTE]
-External collectors such as Azure Monitor or a Telemetry Exporter are valid destinations for CloudHub 2.0 logs. These are reached as generic external collectors via a custom Log4j appender — they don't have a dedicated built-in connector in CloudHub 2.0.
+External collectors such as Azure Monitor or a Telemetry Exporter are valid destinations for CloudHub 2.0 logs. These are reached as generic external collectors via a custom Log4j appender, they don't have a dedicated built-in connector in CloudHub 2.0.
 
 == Requirements and Restrictions
 


### PR DESCRIPTION
## Summary

Clarifies existing content on `ch2-integrate-log-system.adoc` to explicitly state what log types can be streamed and what constraints apply. Addresses case 472905757 where engineers ask whether CH2.0 logs can go to Azure Monitor/Splunk and whether MuleSoft Support helps with appender config.

**Changes:**
- Updated the intro to explicitly state that Mule runtime logs, application logs, and tracing-module logs can all be streamed to external collectors via a custom asynchronous Log4j appender.
- Added a note clarifying that destinations like Azure Monitor and Telemetry Exporter are valid generic external collector targets — not built-in connectors.
- Reorganized the constraints list to lead with the two most actionable constraints: appenders must be asynchronous, and file appenders are removed automatically.
- Kept the existing MuleSoft Support disclaimer and changed "is not" to "isn't" for consistency.

## Test plan

- [ ] Verify page renders correctly at https://docs.mulesoft.com/cloudhub-2/ch2-integrate-log-system
- [ ] Confirm tech SME review for accuracy of log types (runtime, application, tracing-module)