### PR TITLE
W-23445614-ch2-private-spaces-kt

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-networking-guide.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-networking-guide.adoc
@@ -147,6 +147,11 @@ Use a xref:ps-create-configure-tgw.adoc[TGW attachment] to connect a dedicated V
 
 === Firewall Rules and Port Access
 
+[NOTE]
+====
+CloudHub 2.0 private spaces provide configurable inbound and outbound firewall rules, with ports `80` and `443` open by default. Private spaces don't include a built-in Web Application Firewall (WAF) or Layer 7 DDoS protection. If you need these protections, implement them externally.
+====
+
 HTTP Ingress::
 
 By default, ports `443` and `80` are exposed for all external inbound traffic. You can remove or change these ports to restrict inbound traffic.
@@ -167,6 +172,16 @@ You can remove all ingress and egress rules from and to the internet. In this ca
 * Essential AWS services traffic flows are always allowed from Mule applications.
 * You can apply egress rules at the application level. For more information, see xref:ps-config-app-level-egress.adoc[].
 * You can remove the default route to the Internet Gateway. However, for the egress firewall rules to work, the destination IPs must be routable.
+
+
+=== Test Private Space Connectivity
+
+To test connectivity to applications in a private space, use the *Network Tools* application. ICMP ping isn't a supported connectivity test, so a failed ping doesn't mean that your application is down. For download and usage information, see https://help.salesforce.com/s/articleView?id=001115029&type=1[How To Use Network Tools Application].
+
+If traffic reaches the firewall but gets no response, check these common causes:
+
+* A port restriction. The internal load balancer accepts traffic on port `443`.
+* A pod-network CIDR that isn't allowlisted in your connected network.
 
 
 == Regional Services

--- a/cloudhub-2/modules/ROOT/pages/ch2-understand-app-restart.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-understand-app-restart.adoc
@@ -79,7 +79,7 @@ In Private Spaces, CloudHub 2.0 uses Karpenter to manage node lifecycle. When Ka
 
 [NOTE]
 ====
-Apps in a Private Space can restart during Karpenter node downscaling during this weekly window. Design for resiliency so that restarts have minimal impact. See xref:ch2-ha-dr.adoc[].
+Apps in a Private Space can restart during Karpenter node downscaling in this weekly window. These restarts are routine maintenance, not an outage. Design for resiliency so that restarts have minimal impact. See xref:ch2-ha-dr.adoc[].
 ====
 
 == Security Patching


### PR DESCRIPTION
## Summary

Documentation change for W-23445614 (Case Reduction — CloudHub 2.0 Private Spaces).

- **ch2-networking-guide.adoc** — Note under *Firewall Rules and Port Access*: private spaces provide configurable inbound/outbound firewall rules (ports 80/443 open by default) but don't include a built-in WAF or Layer 7 DDoS protection; implement those externally if required.
- **ch2-networking-guide.adoc** — New *Test Private Space Connectivity* subsection: ICMP ping isn't a supported connectivity test (use the Network Tools application); "traffic reaches the firewall but gets no response" is usually a port restriction (internal LB accepts 443) or a pod-network CIDR that isn't allowlisted.
- **ch2-understand-app-restart.adoc** — Clarified that the weekly Karpenter node-downscaling restarts are routine maintenance, not an outage.

## Sources

- GUS W-23445614 — doc request; wording and facts came from its Details__c.
- Evidence cited within the ticket: Case 472724502; W-22261361 (internal LB / port 443), W-21612368 (pod-network CIDR allowlist), W-18200064 (restart/maintenance behavior).

## Test plan

- [ ] Antora build renders both pages without errors
- [ ] Note boxes and the new subsection display correctly
- [ ] Links (Network Tools help article, xrefs) resolve

Made with [Cursor](https://cursor.com)