### PR TITLE
W-23446673: Clarify CloudHub schedules API boundary and disabled-scheduler restart behavior

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-api-reference.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-api-reference.adoc
@@ -82,6 +82,11 @@ For more information, see xref:ps-manage.adoc[] and the https://anypoint.mulesof
 
 Use these endpoints to manage Scheduler component configurations for deployed applications.
 
+[NOTE]
+====
+The CloudHub 1.0 schedules REST API doesn't expose scheduler or domain details for CloudHub 2.0 applications. Manage CloudHub 2.0 schedulers only through the CloudHub 2.0 APIs or the Runtime Manager *Schedules* tab. See xref:ch2-manage-schedules.adoc[].
+====
+
 [%header,cols="10,20,35,35"]
 |===
 |Method |API |Endpoint |Description

--- a/cloudhub-2/modules/ROOT/pages/ch2-api-reference.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-api-reference.adoc
@@ -84,7 +84,7 @@ Use these endpoints to manage Scheduler component configurations for deployed ap
 
 [NOTE]
 ====
-The CloudHub 1.0 schedules REST API doesn't expose scheduler or domain details for CloudHub 2.0 applications. Manage CloudHub 2.0 schedulers only through the CloudHub 2.0 APIs or the Runtime Manager *Schedules* tab. See xref:ch2-manage-schedules.adoc[].
+The CloudHub schedules REST API doesn't expose scheduler or domain details for CloudHub 2.0 applications. Manage CloudHub 2.0 schedulers only through the CloudHub 2.0 APIs or the Runtime Manager *Schedules* tab. See xref:ch2-manage-schedules.adoc[].
 ====
 
 [%header,cols="10,20,35,35"]

--- a/cloudhub-2/modules/ROOT/pages/ch2-manage-schedules.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-manage-schedules.adoc
@@ -12,7 +12,7 @@ On the *Schedules* tab, you can:
 
 [NOTE]
 ====
-The CloudHub 1.0 schedules REST API doesn't expose scheduler or domain details for CloudHub 2.0 applications. Manage CloudHub 2.0 schedulers only through the CloudHub 2.0 APIs or the Runtime Manager *Schedules* tab.
+The CloudHub schedules REST API doesn't expose scheduler or domain details for CloudHub 2.0 applications. Manage CloudHub 2.0 schedulers only through the CloudHub 2.0 APIs or the Runtime Manager *Schedules* tab.
 ====
 
 You configure Scheduler component types as either _fixed frequency_ to trigger at a regular interval or _cron_ to trigger at a date and time based on a specified cron expression.

--- a/cloudhub-2/modules/ROOT/pages/ch2-manage-schedules.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-manage-schedules.adoc
@@ -10,6 +10,11 @@ On the *Schedules* tab, you can:
 * Run the scheduled job immediately, without changing the schedule.
 * Disable or enable the schedule for a flow.
 
+[NOTE]
+====
+The CloudHub 1.0 schedules REST API doesn't expose scheduler or domain details for CloudHub 2.0 applications. Manage CloudHub 2.0 schedulers only through the CloudHub 2.0 APIs or the Runtime Manager *Schedules* tab.
+====
+
 You configure Scheduler component types as either _fixed frequency_ to trigger at a regular interval or _cron_ to trigger at a date and time based on a specified cron expression.
 
 [IMPORTANT]
@@ -263,11 +268,16 @@ include::partial$select-private-space.adoc[tag=clickSchedules]
 You might want to disable a scheduled job if an application you are connecting
 to is undergoing maintenance and then reenable it after maintenance is complete.
 
-CloudHub 2.0 does not run the scheduled job until you reenable the Scheduler.
+CloudHub 2.0 doesn't run the scheduled job until you reenable the Scheduler.
 
 [NOTE]
 ====
 If you disable the scheduler, it might still run once when the application starts. To prevent this behavior, set the `startDelay` property to five seconds in your app using Anypoint Studio. You can also change the `startDelay` value after deployment using the <<override-scheduler-api,Schedulers API>>.
+====
+
+[NOTE]
+====
+A disabled scheduler can revert to enabled after an application restart, rolling restart, or maintenance, so it can run again even though you disabled it. This behavior isn't limited to first startup. After a restart, check the scheduler state on the *Schedules* tab and disable it again if you need it to stay off.
 ====
 
 To disable the Scheduler element:


### PR DESCRIPTION
## Summary

Documentation change for W-23446673 (Case Reduction — CloudHub schedules REST API vs. CloudHub 2.0 apps).

- **ch2-api-reference.adoc** and **ch2-manage-schedules.adoc** — Added a note that the CloudHub schedules REST API doesn't expose scheduler or domain details for CloudHub 2.0 applications, and that CH2.0 schedulers are managed only through CH2.0 APIs or the Runtime Manager Schedules tab.
- **ch2-manage-schedules.adoc** — Added a note that a disabled scheduler can revert to enabled after an application restart, rolling restart, or maintenance (not only first startup), so users should recheck the scheduler state after a restart.

Per-flow schedule enable/disable is already correctly documented as supported on CH2.0, so no correction was needed there.

## Sources

- GUS W-23446673 — doc request; wording and facts came from its Details__c.
- Evidence referenced within the ticket: Case 472652052; W-22913960 (Closed – No Fix – Working as Documented) — basis for the disabled-scheduler restart behavior.

## Related

- Companion change for the CloudHub schedules API reference page in `docs-runtime-manager` (same branch name): https://github.com/mulesoft/docs-runtime-manager/pull/896

## Test plan

- [ ] Antora build renders both pages without errors
- [ ] Note boxes display correctly
- [ ] xref links resolve