### PR TITLE
w-23381614-scheduler-startdelay-cron-kt

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-manage-schedules.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-manage-schedules.adoc
@@ -270,7 +270,7 @@ to is undergoing maintenance and then reenable it after maintenance is complete.
 
 CloudHub 2.0 doesn't run the scheduled job until you reenable the Scheduler.
 
-Even after you disable a scheduler, it can still run once. The condition that causes this and the way to prevent it depend on the schedule type:
+Even after you disable a scheduler, it can still run once. The condition that triggers a disabled scheduler, and the way to prevent an unwanted run, depend on the schedule type:
 
 [%header,cols="1,3,3a"]
 |===

--- a/cloudhub-2/modules/ROOT/pages/ch2-manage-schedules.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-manage-schedules.adoc
@@ -270,10 +270,20 @@ to is undergoing maintenance and then reenable it after maintenance is complete.
 
 CloudHub 2.0 doesn't run the scheduled job until you reenable the Scheduler.
 
-[NOTE]
-====
-If you disable the scheduler, it might still run once when the application starts. To prevent this behavior, set the `startDelay` property to five seconds in your app using Anypoint Studio. You can also change the `startDelay` value after deployment using the <<override-scheduler-api,Schedulers API>>.
-====
+Even after you disable a scheduler, it can still run once. The condition that causes this and the way to prevent it depend on the schedule type:
+
+[%header,cols="1,3,3a"]
+|===
+| Schedule Type | When a Disabled Scheduler Can Still Run Once | How to Prevent It
+
+| Fixed frequency
+| The scheduler can trigger once when the application starts.
+| Set the `startDelay` property to at least five seconds. Configure `startDelay` in your app in Anypoint Studio, or change it after deployment using the <<override-scheduler-api,Schedulers API>>.
+
+| Cron
+| Changing any schedule redeploys the application, and a redeployment that occurs close to the cron trigger time can let a disabled scheduler run once. Because enabling or disabling any scheduler redeploys the app, running several enable or disable actions near a cron trigger time can trigger a disabled scheduler.
+| The `startDelay` property applies only to fixed-frequency schedulers and has no effect on cron schedulers. Avoid enabling or disabling schedulers close to a cron trigger time, and confirm the scheduler state on the *Schedules* tab afterward.
+|===
 
 [NOTE]
 ====


### PR DESCRIPTION
## Summary

Fixes the CloudHub 2.0 scheduler docs bug from GUS [W-23381614](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eJk4qYAC/view).

On `cloudhub-2/modules/ROOT/pages/ch2-manage-schedules.adoc` (*Disable or Enable a Scheduler Element*), the draft:

- Replaces the ambiguous "might still run once" note (which wrongly prescribed `startDelay` for every schedule type) with a comparison table separating fixed-frequency and cron behavior.
- States explicitly that `startDelay` applies only to fixed-frequency schedulers and has no effect on cron schedulers.
- Documents the exact cron condition: changing any schedule redeploys the app, and a redeployment near the cron trigger time can fire a disabled scheduler — so running several enable/disable actions near a cron trigger can trigger a disabled schedule.

The adjacent note about a disabled scheduler reverting to enabled after a restart is already documented and was left untouched (not duplicated).

## Sources

- GUS W-23381614 — the doc request
- GUS W-23325306 — "Signature - Uber - Disabled Cron Schedules Trigger If Multiple Subsequent Schedule Updates (Enable/Disable) Happen" (Closed - Doc/Usability); source for the cron redeployment mechanism
- Existing page — Overridable Properties table (startDelay listed only under Fixed Frequency); "Changing the schedule redeploys your application"
- Slack #discuss-w-23325306 — not consulted (per request)

## Test plan

- [ ] Confirm the AsciiDoc table renders correctly in the docs preview
- [ ] SME/engineering confirms the cron redeployment-near-trigger-time wording

Made with [Cursor](https://cursor.com)