### PR TITLE
W-23426801-ingress-inbound-ports-kt

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ps-config-fw-rules.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ps-config-fw-rules.adoc
@@ -49,7 +49,7 @@ Ports for inbound traffic are not configurable:
 +
 * Port 80 is reserved HTTP.
 * Port 443 is reserved for HTTPS.
-* Other ports under 1024 aren't allowed. Ports 1024 and above are allowed for plain TCP connections, but not for additional HTTP/HTTPS ingress endpoints.
+* Other ports under 1024 aren't allowed. For inbound TCP connections, only ports 30500–32500 are supported, and only for private connections (from within the private space or from a VPN or TGW). You must create a firewall rule to allow traffic on these ports.
 
 --
 . Configure default rules for outbound traffic by selecting the *Protocol* and *Destination* from the drop-down lists:


### PR DESCRIPTION
## Summary

- Replaces the misleading statement "Ports 1024 and above are allowed for plain TCP connections, but not for additional HTTP/HTTPS ingress endpoints" with accurate language
- Clarifies that only ports 30500–32500 are supported for inbound TCP connections, and only for private connections (from within the private space or from a VPN or TGW)
- Notes that a firewall rule must be created to allow traffic on these ports

## Sources

- GUS W-23426801 — "doc update for the misleading Ingress inbound ports documentation" (the doc request; proposed replacement text in Details__c)
- `ch2-networking-guide.adoc` line 162 — confirms the 30500–32500 range and that those ports are "only reachable from within the private space or originated from a VPN or a TGW"

## Test plan

- [ ] Verify the updated text in `ps-config-fw-rules.adoc` under *Ports* (Configuring Firewall Rules section)
- [ ] Confirm port range 30500–32500 and private-connection-only restriction match the ch2-networking-guide