### PR TITLE
Revert "W-20072447-response-timeot" (W-20072447)

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-limits.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-limits.adoc
@@ -18,16 +18,10 @@ Maximum HTTP request size:: 1 GB
 
 Maximum HTTP request timeout:: 300 seconds
 +
-
-This timeout applies to the time it takes for a client to send request data to the CloudHub 2.0 ingress load balancer (Edge). This value is not configurable and applies to both shared spaces and private spaces.
-+
-If the client takes longer than 300 seconds to send the complete request (for example, when uploading large files), the connection is dropped. To handle large data transfers that exceed this limit, break up the request into smaller chunks or implement asynchronous processing.
+This is the read-request timeout, which is the maximum time the ingress controller waits to receive the complete request from the client. This timeout is hardcoded and applies to both shared and private spaces.
 +
 [NOTE]
-====
-Private spaces allow you to configure a separate read response timeout (the time Edge waits for the Mule application to send response data) up to 3600 seconds. For more information, see xref:ps-config-advanced.adoc#configure-http-requests-and-read-response-timeout[Configure HTTP Requests and Read-Response Timeout].
-====
-
+In private spaces, you can configure the read-response timeout (the time CloudHub 2.0 waits for a response from your Mule application) up to 3600 seconds. For more information, see xref:ps-config-advanced.adoc#configure-http-requests-and-read-response-timeout[Configure HTTP Requests and Read-Response Timeout].
 
 Maximum ingress URI size:: 4 KB
 

--- a/cloudhub-2/modules/ROOT/pages/ch2-networking-guide.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-networking-guide.adoc
@@ -52,16 +52,9 @@ The following example shows a Mule application configuration that exposes an HTT
 
 === Load Balancer Connections
 
+For each request a client makes through the CloudHub 2.0 load balancer `(<app>.<space-id>.<region>.cloudhub.io)`, the load balancer maintains two connections: one connection between the client and the load balancer, and another connection between the load balancer and the application. For each connection, the load balancer manages a default idle timeout of 15 seconds that is triggered when no data is sent over either connection. If no data is sent or received during this duration, the load balancer closes both connections.
 
-For each request a client makes through the CloudHub 2.0 load balancer `(<app>.<space-id>.<region>.cloudhub.io)`, the load balancer maintains two connections: one connection between the client and the load balancer (Edge), and another connection between the load balancer and the Mule application. For each connection, the load balancer manages a default idle timeout of 300 seconds that is triggered when no data is sent over either connection. If no data is sent or received during this duration, the load balancer closes both connections.
-
-CloudHub 2.0 also enforces separate timeouts for request and response data transfer:
-
-* *Read Request Timeout* (300 seconds, not configurable): The time Edge waits for the client to send the complete request data. This timeout applies to both shared spaces and private spaces. If the client takes longer than 300 seconds to send the request (for example, when uploading large files), the connection is dropped.
-* *Read Response Timeout* (300 seconds by default, configurable up to 3600 seconds in private spaces): The time Edge waits for the Mule application to send response data. If your Mule application requires more than 300 seconds to process a request and send the response, you can customize this value in the *Advanced* tab of your xref:ps-config-advanced.adoc#configure-http-requests-and-read-response-timeout[private space settings] in Runtime Manager, or via the Mule application xref:mule-runtime::global-settings-configuration.adoc[global configurations] of the xref:mule-runtime::about-mule-configuration.adoc[Mule configuration file].
-
-For long-running data transfers that take longer than 300 seconds to upload from the client to Edge, consider breaking up the request into smaller chunks or implementing asynchronous processing. For more information about timeout limits, see xref:ch2-limits.adoc[].
-
+For connections that take longer than 300 seconds to process from either side, handle the processing asynchronously. You can customize the Read Response Timeout value in the *Advanced* tab of your xref:ps-config-advanced.adoc#configure-http-requests-and-read-response-timeout[private space settings] in Runtime Manager, or via the Mule application xref:mule-runtime::global-settings-configuration.adoc[global configurations] of the xref:mule-runtime::about-mule-configuration.adoc[Mule configuration file].
 
 == DNS Records
 

--- a/cloudhub-2/modules/ROOT/pages/ps-config-advanced.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ps-config-advanced.adoc
@@ -5,11 +5,14 @@ Use options on the *Advanced* tab to:
 * Configure how the ingress load balancer handles HTTP requests.
 * Specify the read-response timeout.
 +
-This value is the amount of time the CloudHub 2.0 ingress load balancer (Edge) waits for the Mule application to send response data back to Edge. If the Mule application does not send response data within the specified time, CloudHub 2.0 drops the request with a 504 error.
+This value is the amount of time the CloudHub 2.0 ingress controller waits to receive a response from your Mule application after forwarding the request. If your application takes longer than the configured time to process the request and start sending the response, CloudHub 2.0 drops the connection with a 504 error.
 +
-This timeout applies to the Mule application processing time and sending the response, not to the time it takes for the client to send the request to Edge. For information about request timeouts, see xref:ch2-limits.adoc[].
+[IMPORTANT]
+====
+This timeout setting is separate from the read-request timeout, which controls how long the CloudHub 2.0 ingress controller waits to receive the full request from the client. The read-request timeout is hardcoded to 300 seconds and isn't configurable. If your client takes longer than 300 seconds to send the complete request, for example, when uploading large files, CloudHub 2.0 drops the connection even if you  configure a longer read-response timeout.
 
-
+For data transfers that exceed 300 seconds, consider breaking the request into smaller chunks or implementing asynchronous processing patterns.
+====
 * Configure ingress load balancer logs levels and download logs.
 * Configure Amazon Web Services (AWS) service roles.
 
@@ -46,11 +49,27 @@ The default read-response timeout is 300 seconds. You can configure this value u
 . Click *Save Changes* or *Discard Changes*.
 
 [NOTE]
-====
 The maximum request size is 1 GB.
-If you are uploading large files (such as CSV files) that take longer than 300 seconds to transfer from the client to Edge, you might encounter a timeout even if you increase the read response timeout. This is because the read request timeout (the time Edge waits for the client to send the request) is hardcoded to 300 seconds and cannot be configured. For long-running data transfers, consider breaking up the request into smaller chunks or implementing asynchronous processing. For more information, see xref:ch2-limits.adoc[].
-====
 
+[[understanding-timeout-behavior]]
+== Understanding Timeout Behavior
+
+CloudHub 2.0 uses multiple timeout settings to manage different phases of request handling:
+
+Read Request Timeout (hardcoded at 300 seconds)::
+The time the CloudHub 2.0 ingress controller waits to receive the complete request from the client. If the client takes longer than 300 seconds to send the entire request payload (for example, uploading a large CSV file), CloudHub 2.0 drops the connection. This timeout is not user-configurable and applies to both shared and private spaces.
+
+Read Response Timeout (user-configurable)::
+The time the CloudHub 2.0 ingress controller waits to receive a response from your Mule application after the request has been forwarded. Configure this timeout in the *Advanced* tab of your private space settings. This setting controls how long your Mule application takes to process the request and begin sending a response.
+
+Connection Idle Timeout (hardcoded at 15 seconds)::
+The time the CloudHub 2.0 ingress controller waits before closing an idle connection when no data is being transferred.
+
+For long-running operations that exceed these timeout limits, consider implementing one of the following approaches:
+
+* Break large requests into smaller chunks
+* Use asynchronous processing patterns where the client receives an immediate acknowledgment and polls for results
+* Implement keep-alive mechanisms to prevent idle timeout during processing
 
 [[configure-ingress-load-balancer-log-levels]]
 == Configure Default Ingress Load Balancer Log Levels 


### PR DESCRIPTION
## Summary

Reverts all changes from [#352](https://github.com/mulesoft/docs-hosting/pull/352) ("W-20072447-response-timeot", merged 2026-08-04), restoring the timeout documentation to its pre-PR state.

This reverts the merge commit `d7a1393` and restores these three files exactly to their state before #352:

- `cloudhub-2/modules/ROOT/pages/ch2-limits.adoc`
- `cloudhub-2/modules/ROOT/pages/ch2-networking-guide.adoc`
- `cloudhub-2/modules/ROOT/pages/ps-config-advanced.adoc`

Changes undone by this revert include: the "ingress controller" → "Edge" terminology rework, the restructured read-request/read-response timeout explanations, the Load Balancer Connections idle-timeout change (15s → 300s), and the removal of the *Understanding Timeout Behavior* section on `ps-config-advanced.adoc`.

## Test plan

- [ ] Confirm the three pages render as they did before #352
- [ ] Confirm no other pages reference content removed by this revert

Made with [Cursor](https://cursor.com)