### PR TITLE
W-23736566-fix-aus-table-kt

### DIFF
--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -501,7 +501,7 @@ Asia Pacific::
 | Basic Alerts | Available | Available | Available
 | Basic Monitoring | Available | Available | Available
 | Custom Dashboards | Planned | Planned | Planned
-| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Available
+| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Planned
 | Integration Intelligence | Available | Available | Available
 | Log Search | Available | Available | Available
 | Logs Raw Data | Available | Available | Available
@@ -539,7 +539,7 @@ Asia Pacific::
 | Generative B2B Message Summary Feature | Available | Planned | Planned
 
 //PRIVATE CLOUD EDITION - ASIA: JA | INDIA | AU
-| xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Available | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
+| xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Not Planned | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
 //RUNTIME MANAGER - ASIA: JA | INDIA | AU
 .4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Available | Available | Available .4+| n/a
@@ -607,8 +607,8 @@ Asia Pacific::
 | Managed Omni Gateway on Runtime Fabric | Available | Available | Available
 | Self-Managed - Connected Mode | Available | Available | Available
 | Self-Managed - Local Mode | Available | Available | Available
-| A2A Governance (Policies) | Available | Available | Planned
-| MCP Governance (Policies) | Available | Available | Planned
+| A2A Governance (Policies) | Available | Available | Available
+| MCP Governance (Policies) | Available | Available | Available
 | LLM Gateway | Available | Available | Available
 
 //HYBRID STANDALONE DEPLOYMENT - ASIA: JA | INDIA | AU

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -83,7 +83,7 @@ Americas::
 | Basic Alerts | Available | Available
 | Basic Monitoring | Available | Available
 | Custom Dashboards | Available | Planned
-| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned
+| Hybrid Standalone Mule (HSA) | Planned | Planned
 | Integration Intelligence | Available | Available
 | Log Search | Available | Available
 | Logs Raw Data | Available | Available
@@ -291,7 +291,7 @@ Europe::
 | Basic Alerts | Available
 | Basic Monitoring | Available
 | Custom Dashboards | Available
-| Hybrid Standalone Mule (HSA) Enabled | Planned
+| Hybrid Standalone Mule (HSA) | Planned
 | Integration Intelligence | Available
 | Log Search | Available
 | Logs Raw Data | Available
@@ -501,7 +501,7 @@ Asia Pacific::
 | Basic Alerts | Available | Available | Available
 | Basic Monitoring | Available | Available | Available
 | Custom Dashboards | Planned | Planned | Planned
-| Hybrid Standalone Mule (HSA) Enabled | Planned | Planned | Planned
+| Hybrid Standalone Mule (HSA) | Planned | Planned | Planned
 | Integration Intelligence | Available | Available | Available
 | Log Search | Available | Available | Available
 | Logs Raw Data | Available | Available | Available


### PR DESCRIPTION
## Summary

Corrects the Australia (AU) column in the Asia Pacific availability table on `hyperforce/modules/ROOT/pages/index.adoc`:

- **Hybrid Standalone Mule (HSA) Enabled** → reverted to *Planned*
- **Anypoint Private Cloud Edition** → *Not Planned*
- **A2A Governance (Policies)** → *Available*
- **MCP Governance (Policies)** → *Available*

## Test plan

- [ ] Confirm the Asia Pacific table renders with the corrected AU values

Made with [Cursor](https://cursor.com)