### PR TITLE
Set Hybrid Standalone Deployment to Planned for Australia (W-23736566)

### DIFF
--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -612,7 +612,7 @@ Asia Pacific::
 | LLM Gateway | Available | Available | Available
 
 //HYBRID STANDALONE DEPLOYMENT - ASIA: JA | INDIA | AU
-| xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | Planned | Available | n/a
+| xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | Planned | Planned | n/a
 
 //IDP - ASIA: JA | INDIA | AU
 | xref:idp::index.adoc[IDP] | n/a | Not planned | Not planned | Not planned | n/a


### PR DESCRIPTION
## Summary

Corrects the Australia (AU) availability for **Hybrid Standalone Deployment** in the Asia Pacific table on `hyperforce/modules/ROOT/pages/index.adoc`: *Available* → *Planned*.

## Test plan

- [ ] Confirm the Asia Pacific table shows Hybrid Standalone Deployment as Planned for AU

Made with [Cursor](https://cursor.com)