### PR TITLE
Fix Omni Gateway notes cell rowspan in Americas and Europe tables (W-23736566)

### DIFF
--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -49,6 +49,7 @@ Americas::
 
 //API MANAGER - AMERICAS: US | CANADA
 .6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned | Available .6+a| For details, refer to:
+
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
 | API Analytics | Not planned | Not planned
@@ -256,7 +257,8 @@ Europe::
 | Links to logs and traces | Planned
 
 //API MANAGER - EUROPE: EU
-.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned .6+a| For details, refer to:   
+.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned .6+a| For details, refer to: 
+  
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
 | API Analytics | Not planned
@@ -465,6 +467,7 @@ Asia Pacific::
 
 //API MANAGER - ASIA: JA | INDIA | AU
 .7+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available | Available .7+a| For details, refer to:
+
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
 | API Analytics | Not planned | Not planned | Not planned

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -186,7 +186,7 @@ Americas::
 | xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Planned | Available | n/a
 
 //OMNI GATEWAY - AMERICAS: US | CANADA
-.7+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned | Available .4+| n/a
+.7+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned | Available .7+| n/a
 | Managed Omni Gateway on Runtime Fabric | Planned | Available
 | Self-Managed - Connected Mode | Planned | Available
 | Self-Managed - Local Mode | Planned | Available
@@ -394,7 +394,7 @@ Europe::
 | xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Planned | n/a
 
 //OMNI GATEWAY - EUROPE: EU
-.7+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned .4+| n/a
+.7+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned .7+| n/a
 | Managed Omni Gateway on Runtime Fabric | Planned
 | Self-Managed - Connected Mode | Planned
 | Self-Managed - Local Mode | Planned


### PR DESCRIPTION
## Summary

Fixes the AsciiDoc rowspan on the Omni Gateway notes cell in `hyperforce/modules/ROOT/pages/index.adoc`. The Omni Gateway row now has seven sub-rows (after adding A2A Governance, MCP Governance, and LLM Gateway), so the notes cell span is corrected from `.4+` to `.7+` in the Americas and Europe tables so they render correctly.

## Test plan

- [ ] Confirm the Americas and Europe Omni Gateway rows render with a single notes cell spanning all seven sub-rows

Made with [Cursor](https://cursor.com)