### PR TITLE
W-23748914: Add United Kingdom Cloud to hosting control plane and runtime region tables

### DIFF
--- a/hosting-home/modules/ROOT/pages/index.adoc
+++ b/hosting-home/modules/ROOT/pages/index.adoc
@@ -63,7 +63,7 @@ MuleSoft provides cloud-managed and self-hosted control plane options. This tabl
 | `gb1.platform.mulesoft.com`
 | United Kingdom
 | MuleSoft-managed control plane hosted in the United Kingdom. See xref:hyperforce::index.adoc#deploy-mule-apps-to-control-planes[Deploy Mule Apps to Control Planes].
-| UK data residency
+| United Kingdom data residency
 
 | MuleSoft Government Cloud
 | `gov.anypoint.mulesoft.com`

--- a/hosting-home/modules/ROOT/pages/index.adoc
+++ b/hosting-home/modules/ROOT/pages/index.adoc
@@ -59,6 +59,12 @@ MuleSoft provides cloud-managed and self-hosted control plane options. This tabl
 | MuleSoft-managed control plane hosted in Australia. See xref:hyperforce::index.adoc#deploy-mule-apps-to-control-planes[Deploy Mule Apps to Control Planes].
 | Australian data residency
 
+| United Kingdom Cloud
+| `gb1.platform.mulesoft.com`
+| United Kingdom
+| MuleSoft-managed control plane hosted in the United Kingdom. See xref:hyperforce::index.adoc#deploy-mule-apps-to-control-planes[Deploy Mule Apps to Control Planes].
+| UK data residency
+
 | MuleSoft Government Cloud
 | `gov.anypoint.mulesoft.com`
 | United States
@@ -109,6 +115,9 @@ This table lists the runtime regions available for each control plane:
 
 | https://au1.platform.mulesoft.com[Australia Cloud]
 | Asia Pacific | Australia (Sydney) | `ap-southeast-2`
+
+| https://gb1.platform.mulesoft.com[United Kingdom Cloud]
+| Europe | United Kingdom (London) | `eu-west-2`
 
 | https://gov.anypoint.mulesoft.com[MuleSoft Government Cloud]
 | US Government | US GovCloud (West) | `us-gov-west`


### PR DESCRIPTION
## Summary

Replicates the Australia Cloud changes from PR #454 for United Kingdom Cloud (`gb1.platform.mulesoft.com`, London).

- Adds United Kingdom Cloud (`gb1.platform.mulesoft.com`, United Kingdom, UK data residency) to the control plane options table.
- Adds United Kingdom Cloud to the runtime regions table (Europe | United Kingdom (London) | `eu-west-2`).

## Notes

- Values sourced from the MuleSoft Hyperforce Instance Details (United Kingdom = London / Great Britain, access URL `gb1.platform.mulesoft.com`, Falcon instance `aws-prod13-euwest2` = `eu-west-2`).

Made with [Cursor](https://cursor.com)