### PR TITLE
W-23748914: Add United Kingdom Cloud to CloudHub 2.0 region tables

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/_partials/region-table-long.adoc
+++ b/cloudhub-2/modules/ROOT/pages/_partials/region-table-long.adoc
@@ -32,6 +32,9 @@
 | https://au1.platform.mulesoft.com[Australia Cloud]
 | Asia Pacific | Australia (Sydney) | `ap-southeast-2` | `myapp-uniq-id.aus-s1.au1.cloudhub.io` | `<app>.internal-<space-id>.aus-s1.au1.cloudhub.io`
 
+| https://gb1.platform.mulesoft.com[United Kingdom Cloud]
+| Europe | United Kingdom (London) | `eu-west-2` | `myapp-uniq-id.gbr-e1.gb1.cloudhub.io` | `<app>.internal-<space-id>.gbr-e1.gb1.cloudhub.io`
+
 | https://gov.anypoint.mulesoft.com[MuleSoft Government Cloud]
 | US Government | US GovCloud (West) | `us-gov-west` | `myapp.usg-w1.gov.cloudhub.io` | -
 |===

--- a/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-architecture.adoc
@@ -168,6 +168,9 @@ The following table summarizes what DNS records are available for your applicati
 
 | https://au1.platform.mulesoft.com[Australia Cloud]
 | Asia Pacific | Australia (Sydney) | aus-s1 | `cloudhub-ap-southeast-2` | `myapp-_uniq-id_._shard_.aus-s1.au1.cloudhub.io` | `Cloudhub-AP-Southeast-2`
+
+| https://gb1.platform.mulesoft.com[United Kingdom Cloud]
+| Europe | United Kingdom (London) | gbr-e1 | `cloudhub-eu-west-2` | `myapp-_uniq-id_._shard_.gbr-e1.gb1.cloudhub.io` | `Cloudhub-EU-West-2`
 |===
 
 For example, if you deploy an application named `myapp` to Canada (Montreal), the domain used to access the application is `myapp-_uniq-id_._shard_.can-c1.cloudhub.io`.


### PR DESCRIPTION
## Summary

Replicates the Australia Cloud changes from PR #456 for United Kingdom Cloud (`gb1.platform.mulesoft.com`).

- **`_partials/region-table-long.adoc`**: Added United Kingdom Cloud row with region `eu-west-2`, DNS example `myapp-uniq-id.gbr-e1.gb1.cloudhub.io`, and internal DNS example `<app>.internal-<space-id>.gbr-e1.gb1.cloudhub.io`.
- **`ch2-architecture.adoc`**: Added United Kingdom Cloud row to the DNS records table with shard prefix `gbr-e1`, bucket `cloudhub-eu-west-2`, and DNS pattern `myapp-_uniq-id_._shard_.gbr-e1.gb1.cloudhub.io`.

## Notes

- Shard prefix `gbr-e1` matches the existing US Cloud "UK (London)" row already in the region table for `eu-west-2`.

Made with [Cursor](https://cursor.com)