### PR TITLE
W-23736566: Align Europe API Visualizer rows with Americas and Asia Pacific tables

### DIFF
--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -347,9 +347,8 @@ Europe::
 | xref:studio::index.adoc[Anypoint Studio] | n/a | Planned | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
 
 //API VISUALIZER - EUROPE: EU
-.3+| xref:visualizer::index.adoc[API Visualizer] | Architecture | Available .3+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
-| Policies | Available
-| Troubleshooting | Available
+.2+| xref:visualizer::index.adoc[API Visualizer] | Architecture and Policies View | Available .2+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
+| Troubleshooting View | Available
 
 //API COMMUNITY MANAGER - EUROPE: EU
 | xref:api-community-manager::index.adoc[API Community Manager] | n/a | Planned | n/a


### PR DESCRIPTION
## Summary

Makes the API Visualizer rows in the **Europe** feature-availability table consistent with the Americas and Asia Pacific tables.

- Replaced the three separate rows (`Architecture`, `Policies`, `Troubleshooting`) with the two-feature format used elsewhere: `Architecture and Policies View` and `Troubleshooting View`.
- Updated the rowspan from `.3+` to `.2+` accordingly.

EU Cloud statuses: Architecture and Policies View = Available, Troubleshooting View = Available.

Made with [Cursor](https://cursor.com)