### PR TITLE
W-23749618: Generalize CloudHub 2.0 region description in hosting overview

### DIFF
--- a/hosting-home/modules/ROOT/pages/index.adoc
+++ b/hosting-home/modules/ROOT/pages/index.adoc
@@ -129,7 +129,7 @@ MuleSoft provides different options for hosting the runtime plane:
 | Runtime Option | Description | Managed By | Key Characteristics
 
 | CloudHub 2.0
-| Fully managed, containerized integration platform as a service (iPaaS) for deploying APIs and integrations as lightweight containers in the cloud. Supports deployments across 12 regions globally with single or shared tenancy.
+| Fully managed, containerized integration platform as a service (iPaaS) for deploying APIs and integrations as lightweight containers in the cloud. Supports deployments across all runtime plane regions.
 | MuleSoft
 | Auto-scaling, high availability, dynamic infrastructure. See xref:cloudhub-2::index.adoc[CloudHub 2.0].
 


### PR DESCRIPTION
## Summary
- Updates the CloudHub 2.0 runtime option description in the Hosting overview (`hosting-home/modules/ROOT/pages/index.adoc`).
- Replaces the hardcoded "across 12 regions globally with single or shared tenancy" wording with "across all runtime plane regions" so the description stays accurate as cloud regions are added.

## Test plan
- [ ] Build the `hosting-home` component and confirm the Runtime Plane Hosting Options table renders with the updated CloudHub 2.0 description.