### PR TITLE
W-23736566: Set Agent Visualizer Canada logs link to Available

### DIFF
--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -45,7 +45,7 @@ Americas::
 
 //AGENT VISUALIZER - AMERICAS: US | CANADA
 .3+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Planned | Available .3+| n/a
-| Links to logs | Planned | Planned
+| Links to logs | Planned | Available
 | Links to traces | Planned | Planned
 
 //API MANAGER - AMERICAS: US | CANADA


### PR DESCRIPTION
## Summary
- Updates the Hyperforce feature availability table so that the Agent Visualizer **Links to logs** feature for **Canada** is marked **Available** (previously **Planned**).

## Test plan
- [ ] Verify the Americas table renders correctly with the Canada "Links to logs" cell showing "Available".