### PR TITLE
W-23830808: Merge Hyperforce clouds in control/runtime plane compatibility table

### DIFF
--- a/hosting-home/modules/ROOT/pages/index.adoc
+++ b/hosting-home/modules/ROOT/pages/index.adoc
@@ -180,12 +180,12 @@ This matrix shows which runtime plane options are supported in each control plan
 
 [%header%autowidth.spread]
 |===
-| Runtime Plane | US Cloud | EU Cloud | Canada Cloud | Japan Cloud | MuleSoft Government Cloud | Anypoint Platform PCE
+| Runtime Plane | US Cloud | EU Cloud | Canada Cloud, Japan Cloud, India Cloud, Australia Cloud | MuleSoft Government Cloud | Anypoint Platform PCE
 
-| CloudHub 2.0 | Yes | Yes | Yes | Yes | No | No
-| CloudHub | Yes | Yes | No | No | Yes | No
-| Runtime Fabric | Yes | Yes | Yes | Yes | No | No
-| Hybrid Standalone Runtimes | Yes | Yes | No | No | Yes | Yes
+| CloudHub 2.0 | Yes | Yes | Yes | No | No
+| CloudHub | Yes | Yes | No | Yes | No
+| Runtime Fabric | Yes | Yes | Yes | No | No
+| Hybrid Standalone Runtimes | Yes | Yes | No | Yes | Yes
 |===
 
 == Choosing a Hosting Option


### PR DESCRIPTION
## Summary
- Merge Canada Cloud and Japan Cloud columns in the Control Plane and Runtime Plane Compatibility table (identical support values)
- Include India Cloud and Australia Cloud in the same merged column

## Test plan
- [ ] Preview hosting-home overview page and confirm the compatibility table renders with one Hyperforce clouds column
- [ ] Verify Yes/No values match prior Canada/Japan support for CloudHub 2.0, CloudHub, Runtime Fabric, and Hybrid Standalone Runtimes