### PR TITLE
W-23852067: Mark US Cloud Hyperforce features as Available

### DIFF
--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -38,44 +38,44 @@ Americas::
 |Component |Feature Description |US Cloud |Canada Cloud |Notes
 
 //ACCESS MANAGEMENT - AMERICAS: US | CANADA
-.4+| xref:access-management::index.adoc[Access Management] | All other features | Planned | Available .4+| n/a
-| Audit Logging | Planned | Available
-| Business Groups | Planned | Available
-| External Identity Management Integration | Planned | Available
+.4+| xref:access-management::index.adoc[Access Management] | All other features | Available | Available .4+| n/a
+| Audit Logging | Available | Available
+| Business Groups | Available | Available
+| External Identity Management Integration | Available | Available
 
 //AGENT VISUALIZER - AMERICAS: US | CANADA
-.3+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Planned | Available .3+| n/a
-| Links to logs | Planned | Available
-| Links to traces | Planned | Planned
+.3+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Available | Available .3+| n/a
+| Links to logs | Available | Available
+| Links to traces | Available | Planned
 
 //API MANAGER - AMERICAS: US | CANADA
-.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned | Available .6+a| For details, refer to:
+.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available | Available .6+a| For details, refer to:
 
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
 | API Analytics | Not planned | Not planned
-| API Alerts | Planned | Planned
+| API Alerts | Available | Planned
 | API Manager 1.x | Not planned | Not planned
-| API Manager 2.x | Planned | Available
-| API Console Proxy/Trusted Domains | Planned | Planned
+| API Manager 2.x | Available | Available
+| API Console Proxy/Trusted Domains | Available | Planned
 
 //CLI - AMERICAS: US | CANADA
-.2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Planned | Available .2+| n/a
-| API Catalog CLI | Planned | Available
+.2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Available| Available .2+| n/a
+| API Catalog CLI | Available | Available
 
 //CODE BUILDER - AMERICAS: US | CANADA
-.5+| xref:anypoint-code-builder::index.adoc[Anypoint Code Builder] | All other features | Planned | Available .5+| For details, refer to xref:anypoint-code-builder::index.adoc#us-eu-clouds[Anypoint Code Builder Cloud Hosts]
-| Agent Network Projects (Agent Broker) | Planned | Available
-| MuleSoft Vibes | Planned | Available
-| Generative Data Transformations | Planned | Available
-| Generative MUnit | Planned | Available
+.5+| xref:anypoint-code-builder::index.adoc[Anypoint Code Builder] | All other features | Available | Available .5+| For details, refer to xref:anypoint-code-builder::index.adoc#us-eu-clouds[Anypoint Code Builder Cloud Hosts]
+| Agent Network Projects (Agent Broker) | Available | Available
+| MuleSoft Vibes | Available | Available
+| Generative Data Transformations | Available | Available
+| Generative MUnit | Available | Available
 
 //EXCHANGE - AMERICAS: US | CANADA
-.5+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Planned | Available .5+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
-| AI Documentation Generation | Planned | Available
+.5+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Available | Available .5+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
+| AI Documentation Generation | Available | Available
 | Amazon Cloud Front | Planned | Planned
-| Agent, MCP, and LLM assets (Agent Registry) | Planned | Available
-| Agent Scanners | Planned | Available
+| Agent, MCP, and LLM assets (Agent Registry) | Available | Available
+| Agent Scanners | Available | Available
 
 //MONITORING - AMERICAS: US | CANADA
 .12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Available | Planned .12+a| For details, refer to:
@@ -95,38 +95,38 @@ Americas::
 | Traces Beta | Available | Not planned
 
 //MQ - AMERICAS: US | CANADA
-.18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Planned | Available .18+a| For details, refer to:
+.18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Available | Available .18+a| For details, refer to:
 
 * xref:mq::index.adoc#mq-features-control-plane[Anypoint MQ Features by Control Plane]
 * xref:mq::index.adoc#mq-on-hyperforce[Limitations by Control Plane]
 * xref:mq::mq-faq.adoc#mq-hyperforce[Anypoint MQ Available Regions]
-| Anypoint MQ Admin API | Planned | Available
-| Anypoint MQ Broker API | Planned | Available
-| Anypoint MQ Connector earlier than 4.x | Planned | Not planned
-| Anypoint MQ Connector versions 4.x and later | Planned | Available
-| Anypoint MQ Stats API (Anypont MQ Stats only) | Planned | Available
-| Anypoint MQ Stats API (Usage Metrics) | Planned | Not planned
-| Client Apps | Planned | Not planned
-| CloudHub 1.0 Deployments | Planned | Not planned
-| Connected Apps | Planned | Available
-| Cross-Region Failover | Planned | Not planned
-| Encrypted Queues | Planned | Available
-| FIFO Exchange | Planned | Available
-| Message Exchanges | Planned | Available
-| Message Routing | Planned | Available
+| Anypoint MQ Admin API | Available | Available
+| Anypoint MQ Broker API | Available | Available
+| Anypoint MQ Connector earlier than 4.x | Available | Not planned
+| Anypoint MQ Connector versions 4.x and later | Available | Available
+| Anypoint MQ Stats API (Anypont MQ Stats only) | Available | Available
+| Anypoint MQ Stats API (Usage Metrics) | Not planned | Not planned
+| Client Apps | Available | Not planned
+| CloudHub 1.0 Deployments | Available | Not planned
+| Connected Apps | Available | Available
+| Cross-Region Failover | Available | Not planned
+| Encrypted Queues | Available | Available
+| FIFO Exchange | Available | Available
+| Message Exchanges | Available | Available
+| Message Routing | Available | Available
 | Unencrypted Queues | Not planned | Not planned
 | Usage Charts (Access Management) | Not planed | Not planned
-| Usage Reports (Usage) | Planned | Available
+| Usage Reports (Usage) | Available | Available
 
 //PARTNER MANAGER - AMERICAS: US | CANADA
-.2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Planned | Available .2+| n/a
-| Generative B2B Message Summary Feature | Planned | Available
+.2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Available | Available .2+| n/a
+| Generative B2B Message Summary Feature | Available | Available
 
 //PRIVATE CLOUD EDITION - AMERICAS: US | CANADA
 | xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Not planned | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
 //RUNTIME MANAGER - AMERICAS: US | CANADA
-.4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Planned | Available .4+| n/a
+.4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Available | Available .4+| n/a
 | Insights | Not planned | Not planned
 | Log Tailing | Available | Available
 | Monitoring for Hybrid Standalone Deployments | Planned | Not planned
@@ -135,62 +135,62 @@ Americas::
 | xref:anypoint-security::index-secrets-manager.adoc[Anypoint Security Secrets Manager] | n/a | Planned | Available | n/a
 
 //STUDIO - AMERICAS: US | CANADA
-| xref:studio::index.adoc[Anypoint Studio] | n/a | Planned | Available | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
+| xref:studio::index.adoc[Anypoint Studio] | n/a | Available | Available | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
 
 //API VISUALIZER - AMERICAS: US | CANADA
 .2+| xref:visualizer::index.adoc[API Visualizer] | Architecture and Policies View | Available | Available .2+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
 | Troubleshooting View | Available | Planned
 
 //API COMMUNITY MANAGER - AMERICAS: US | CANADA
-| xref:api-community-manager::index.adoc[API Community Manager] | n/a | Planned | Available | n/a
+| xref:api-community-manager::index.adoc[API Community Manager] | n/a | Available | Available | n/a
 
 //API DESIGNER - AMERICAS: US | CANADA
-| xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Planned | Not planned | n/a
+| xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Available | Not planned | n/a
 
 //API EXPERIENCE HUB - AMERICAS: US | CANADA
-| xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Planned | Available | n/a
+| xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Available | Available | n/a
 
 //API FUNCTIONAL MONITORING - AMERICAS: US | CANADA
-| xref:api-functional-monitoring::index.adoc[API Functional Monitoring] | n/a | Planned | Available | n/a
+| xref:api-functional-monitoring::index.adoc[API Functional Monitoring] | n/a | Available | Available | n/a
 
 //API GOVERNANCE - AMERICAS: US | CANADA
-| xref:api-governance::index.adoc[API Governance] | n/a | Planned | Available | n/a
+| xref:api-governance::index.adoc[API Governance] | n/a | Available | Available | n/a
 
 //API MOCKING SERVICE - AMERICAS: US | CANADA
-| xref:design-center::design-mocking-service.adoc[API Mocking Service] | n/a | Planned | Available | n/a
+| xref:design-center::design-mocking-service.adoc[API Mocking Service] | n/a | Available | Available | n/a
 
 //CLOUDHUB - AMERICAS: US | CANADA
 .2+| xref:cloudhub::index.adoc[CloudHub] | All other features | Planned | Not planned .2+| n/a
 | Global CloudHub Deployment | Planned | Not planned
 
 //CLOUDHUB 2.0 - AMERICAS: US | CANADA
-.6+| xref:cloudhub-2::index.adoc[CloudHub 2.0] | All other features | Planned | Available .6+a| For details, refer to:
+.6+| xref:cloudhub-2::index.adoc[CloudHub 2.0] | All other features | Available | Available .6+a| For details, refer to:
 
 * xref:cloudhub-2::index.adoc#cloudhub2-hyperforce[CloudHub 2.0 Features by Control Plane]
 * xref:cloudhub-2::ch2-architecture.adoc#regions-and-dns-records[Runtime Plane Regions and DNS Records]
-| Deleting the Default Egress Route | Planned | Available
-| Global Cloud Deployment | Planned | Not planned
-| Private Space | Planned | Available
-| Private Space - VPN | Planned | Available
-| Shared Spaces | Planned | Available
+| Deleting the Default Egress Route | Available | Available
+| Global Cloud Deployment | Available | Not planned
+| Private Space | Available | Available
+| Private Space - VPN | Available | Available
+| Shared Spaces | Available | Available
 
 //CONNECTORS - AMERICAS: US | CANADA
-| xref:connectors::index.adoc[Connectors] |  | Planned | Available |
+| xref:connectors::index.adoc[Connectors] |  | Available | Available |
 
 //DATAWEAVE - AMERICAS: US | CANADA
-| xref:dataweave::index.adoc[DataWeave] | n/a | Planned | Available | n/a
+| xref:dataweave::index.adoc[DataWeave] | n/a | Available | Available | n/a
 
 //DATALOADER - AMERICAS: US | CANADA
-| Dataloader | n/a | Planned | Not planned | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
+| Dataloader | n/a | Available | Not planned | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
 
 //ENHANCED MULESOFT EXPERIENCE AND REMOTE MCP SERVER - AMERICAS: US | CANADA
-| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Planned | Available | n/a
+| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | Available | n/a
 
 //OMNI GATEWAY - AMERICAS: US | CANADA
-.7+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned | Available .7+| n/a
-| Managed Omni Gateway on Runtime Fabric | Planned | Available
-| Self-Managed - Connected Mode | Planned | Available
-| Self-Managed - Local Mode | Planned | Available
+.7+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Available | Available .7+| n/a
+| Managed Omni Gateway on Runtime Fabric | Available | Available
+| Self-Managed - Connected Mode | Available | Available
+| Self-Managed - Local Mode | Available | Available
 | A2A Governance (Policies) | Available | Available 
 | MCP Governance (Policies) | Available | Available 
 | LLM Gateway | Available | Available 
@@ -199,35 +199,35 @@ Americas::
 | xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | Planned | n/a
 
 //IDP - AMERICAS: US | CANADA
-| xref:idp::index.adoc[IDP] | n/a | Planned | Not planned | n/a
+| xref:idp::index.adoc[IDP] | n/a | Available | Not planned | n/a
 
 //MULE GATEWAY - AMERICAS: US | CANADA
-.2+| xref:gateway-home::index.adoc#anypoint_mule_gateway[Mule Gateway] | Mule Gateway Proxies | Planned | Available .2+| n/a
-| Mule Gateway Policies | Planned | Available
+.2+| xref:gateway-home::index.adoc#anypoint_mule_gateway[Mule Gateway] | Mule Gateway Proxies | Available | Available .2+| n/a
+| Mule Gateway Policies | Available | Available
 
 //MULE RUNTIME ENGINE - AMERICAS: US | CANADA
-.2+| xref:mule-runtime::index.adoc[Mule runtime engine] | All features | Planned | Available .2+| Mule 3 is not supported as it reached EOL.
-| Diagnostics Agent | Planned | Available
+.2+| xref:mule-runtime::index.adoc[Mule runtime engine] | All features | Available | Available .2+| Mule 3 is not supported as it reached EOL.
+| Diagnostics Agent | Available | Available
 
 //MUNIT - AMERICAS: US | CANADA
-| xref:munit::index.adoc[MUnit] | All features | Planned | Available | n/a
+| xref:munit::index.adoc[MUnit] | All features | Available | Available | n/a
 
 //OBJECT STORE V2 - AMERICAS: US | CANADA
-.6+| xref:object-store::index.adoc[Object Store V2] | All other features | Planned | Available .6+a| For details, refer to:
+.6+| xref:object-store::index.adoc[Object Store V2] | All other features | Available | Available .6+a| For details, refer to:
 
 * xref:object-store::index.adoc#os-features-control-plane[Object Store Features by Control Plane]
 * xref:object-store::osv2-faq.adoc#osv2-regions[Object Store v2 Regions]
-| Connected Apps | Planned | Available
-| CloudHub 1.0 Deployments | Planned | Not planned
+| Connected Apps | Available | Available
+| CloudHub 1.0 Deployments | Available | Not planned
 | Object Store v2 Stats API | Not planned | Not planned
-| Usage Reports (Usage) | Planned | Available
+| Usage Reports (Usage) | Available | Available
 | Usage Charts (Access Management) | Not planned | Not planned
 
 //RPA - AMERICAS: US | CANADA
-| xref:rpa-home::index.adoc[RPA] | n/a | Planned | Not planned | n/a
+| xref:rpa-home::index.adoc[RPA] | n/a | Available | Not planned | n/a
 
 //RUNTIME FABRIC - AMERICAS: US | CANADA
-| xref:runtime-fabric::index.adoc[Runtime Fabric] | n/a | Planned | Available a| Contact your account manager to unlock this capability. For more information, refer to:
+| xref:runtime-fabric::index.adoc[Runtime Fabric] | n/a | Available | Available a| Contact your account manager to unlock this capability. For more information, refer to:
 
 * xref:runtime-fabric::install-self-managed-network-configuration.adoc[Configuring Your Network to Support Runtime Fabric]
 * xref:runtime-fabric::configure-local-registry.adoc[Using a Local Registry with Runtime Fabric]
@@ -235,7 +235,7 @@ Americas::
 * xref:runtime-fabric::use-anypoint-monitoring.adoc[Using Anypoint Monitoring]
 
 //USAGE REPORTS - AMERICAS: US | CANADA
-| xref:general::usage-reports.adoc[Usage Reports] | n/a | Planned | Available | n/a
+| xref:general::usage-reports.adoc[Usage Reports] | n/a | Available | Available | n/a
 |===
 --
 

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -673,10 +673,10 @@ This table indicates the available and planned cloud regions for Hyperforce:
 | Control Plane | Geographic Area | Platform URL | Status
 
 | https://anypoint.mulesoft.com[US Cloud]
-| Americas | `anypoint.mulesoft.com` | Planned
+| Americas | `anypoint.mulesoft.com` | Available
 
 | https://eu1.anypoint.mulesoft.com[EU Cloud]
-| Europe | `eu1.anypoint.mulesoft.com` | Planned
+| Europe | `eu1.anypoint.mulesoft.com` | Available
 
 | https://ca1.platform.mulesoft.com[Canada Cloud]
 | Americas | `ca1.platform.mulesoft.com` | Available

--- a/hyperforce/modules/ROOT/pages/index.adoc
+++ b/hyperforce/modules/ROOT/pages/index.adoc
@@ -60,7 +60,7 @@ Americas::
 | API Console Proxy/Trusted Domains | Available | Planned
 
 //CLI - AMERICAS: US | CANADA
-.2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Available| Available .2+| n/a
+.2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Available | Available .2+| n/a
 | API Catalog CLI | Available | Available
 
 //CODE BUILDER - AMERICAS: US | CANADA
@@ -115,7 +115,7 @@ Americas::
 | Message Exchanges | Available | Available
 | Message Routing | Available | Available
 | Unencrypted Queues | Not planned | Not planned
-| Usage Charts (Access Management) | Not planed | Not planned
+| Usage Charts (Access Management) | Not planned | Not planned
 | Usage Reports (Usage) | Available | Available
 
 //PARTNER MANAGER - AMERICAS: US | CANADA
@@ -247,44 +247,44 @@ Europe::
 |Component |Feature Description |EU Cloud |Notes
 
 //ACCESS MANAGEMENT - EUROPE: EU
-.4+| xref:access-management::index.adoc[Access Management] | All other features | Planned .4+| n/a
-| Audit Logging | Planned
-| Business Groups | Planned
-| External Identity Management Integration | Planned
+.4+| xref:access-management::index.adoc[Access Management] | All other features | Available .4+| n/a
+| Audit Logging | Available
+| Business Groups | Available
+| External Identity Management Integration | Available
 
 //AGENT VISUALIZER - EUROPE: EU
-.3+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Planned .3+| n/a
-| Links to logs | Planned 
-| Links to traces | Planned
+.3+| xref:agent-visualizer::index.adoc[Agent Visualizer] | All other features | Available .3+| n/a
+| Links to logs | Available
+| Links to traces | Available
 
 //API MANAGER - EUROPE: EU
-.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Planned .6+a| For details, refer to: 
-  
+.6+| xref:api-manager::latest-overview-concept.adoc[Anypoint API Manager] | All other features | Available .6+a| For details, refer to:
+
 * xref:api-manager::analytics-landing-page.adoc[Mule API Analytics]
 * xref:api-manager::using-api-alerts.adoc[Reviewing Alerts Concepts]
 | API Analytics | Not planned
-| API Alerts | Planned
+| API Alerts | Available
 | API Manager 1.x | Not planned
-| API Manager 2.x | Planned
-| API Console Proxy/Trusted Domains | Planned
+| API Manager 2.x | Available
+| API Console Proxy/Trusted Domains | Available
 
 //CLI - EUROPE: EU
-.2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Planned .2+| n/a
-| API Catalog CLI | Planned
+.2+| xref:anypoint-cli::index.adoc[Anypoint CLI] | All features | Available .2+| n/a
+| API Catalog CLI | Available
 
 //CODE BUILDER - EUROPE: EU
-.5+| xref:anypoint-code-builder::index.adoc[Anypoint Code Builder] | All other features | Planned .5+| For details, refer to xref:anypoint-code-builder::index.adoc#us-eu-clouds[Anypoint Code Builder Cloud Hosts]
-| Agent Network Projects (Agent Broker) | Planned
-| MuleSoft Vibes | Planned
-| Generative Data Transformations | Planned
-| Generative MUnit | Planned
+.5+| xref:anypoint-code-builder::index.adoc[Anypoint Code Builder] | All other features | Available .5+| For details, refer to xref:anypoint-code-builder::index.adoc#us-eu-clouds[Anypoint Code Builder Cloud Hosts]
+| Agent Network Projects (Agent Broker) | Available
+| MuleSoft Vibes | Available
+| Generative Data Transformations | Available
+| Generative MUnit | Available
 
 //EXCHANGE - EUROPE: EU
-.5+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Planned .5+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
-| AI Documentation Generation | Planned
+.5+| xref:exchange::index.adoc[Anypoint Exchange] | All other features | Available .5+| For details, refer to xref:exchange::index.adoc#exchange-on-control-planes[Anypoint Exchange on Control Planes]
+| AI Documentation Generation | Available
 | Amazon Cloud Front | Planned
-| Agent, MCP, and LLM assets (Agent Registry) | Planned
-| Agent Scanners | Planned
+| Agent, MCP, and LLM assets (Agent Registry) | Available
+| Agent Scanners | Available
 
 //MONITORING - EUROPE: EU
 .12+| xref:monitoring::index.adoc[Anypoint Monitoring] | Advanced Alerts | Available .12+a| For details, refer to:
@@ -304,140 +304,139 @@ Europe::
 | Traces Beta | Available
 
 //MQ - EUROPE: EU
-.18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Planned .18+a| For details, refer to:
+.18+| xref:mq::index.adoc[Anypoint MQ] | All other features | Available .18+a| For details, refer to:
 
 * xref:mq::index.adoc#mq-features-control-plane[Anypoint MQ Features by Control Plane]
 * xref:mq::index.adoc#mq-on-hyperforce[Limitations by Control Plane]
 * xref:mq::mq-faq.adoc#mq-hyperforce[Anypoint MQ Available Regions]
-| Anypoint MQ Admin API | Planned
-| Anypoint MQ Broker API | Planned
-| Anypoint MQ Connector earlier than 4.x | Planned
-| Anypoint MQ Connector versions 4.x and later | Planned
-| Anypoint MQ Stats API (Anypont MQ Stats only) | Planned
-| Anypoint MQ Stats API (Usage Metrics) | Planned
-| Client Apps | Planned
-| CloudHub 1.0 Deployments | Planned
-| Connected Apps | Planned
-| Cross-Region Failover | Planned
-| Encrypted Queues | Planned
-| FIFO Exchange | Planned
-| Message Exchanges | Planned
-| Message Routing | Planned
+| Anypoint MQ Admin API | Available
+| Anypoint MQ Broker API | Available
+| Anypoint MQ Connector earlier than 4.x | Available
+| Anypoint MQ Connector versions 4.x and later | Available
+| Anypoint MQ Stats API (Anypont MQ Stats only) | Available
+| Anypoint MQ Stats API (Usage Metrics) | Not planned
+| Client Apps | Available
+| CloudHub 1.0 Deployments | Available
+| Connected Apps | Available
+| Cross-Region Failover | Available
+| Encrypted Queues | Available
+| FIFO Exchange | Available
+| Message Exchanges | Available
+| Message Routing | Available
 | Unencrypted Queues | Not planned
 | Usage Charts (Access Management) | Not planned
-| Usage Reports (Usage) | Planned
+| Usage Reports (Usage) | Available
 
 //PARTNER MANAGER - EUROPE: EU
-.2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Planned .2+| n/a
-| Generative B2B Message Summary Feature | Planned
+.2+| xref:partner-manager::index.adoc[Anypoint Partner Manager] | All other features | Available .2+| n/a
+| Generative B2B Message Summary Feature | Available
 
 //PRIVATE CLOUD EDITION - EUROPE: EU
 | xref:private-cloud::index.adoc[Anypoint Private Cloud Edition] | n/a | Not planned | Anypoint Private Cloud Edition (Anypoint Platform PCE) is a complete software package that you install and manage entirely within your private network. PCE runs exclusively on your infrastructure and isn't hosted or managed on any public cloud by MuleSoft.
 
 //RUNTIME MANAGER - EUROPE: EU
-.4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Planned .4+| n/a
+.4+| xref:runtime-manager::index.adoc[Anypoint Runtime Manager] | All non Monitoring features | Available .4+| n/a
 | Insights | Not planned
 | Log Tailing | Available
-| Monitoring for Hybrid Standalone Deployments | Available
+| Monitoring for Hybrid Standalone Deployments | Planned
 
 //SECURITY SECRETS MANAGER - EUROPE: EU
 | xref:anypoint-security::index-secrets-manager.adoc[Anypoint Security Secrets Manager] | n/a | Planned | n/a
 
 //STUDIO - EUROPE: EU
-| xref:studio::index.adoc[Anypoint Studio] | n/a | Planned | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
+| xref:studio::index.adoc[Anypoint Studio] | n/a | Available | For details, refer to xref:studio::hyperforce-configuration.adoc[Configuring Anypoint Studio for Control Planes]
 
 //API VISUALIZER - EUROPE: EU
 .2+| xref:visualizer::index.adoc[API Visualizer] | Architecture and Policies View | Available .2+| For details, refer to xref:visualizer::index.adoc[API Visualizer]
 | Troubleshooting View | Available
 
 //API COMMUNITY MANAGER - EUROPE: EU
-| xref:api-community-manager::index.adoc[API Community Manager] | n/a | Planned | n/a
+| xref:api-community-manager::index.adoc[API Community Manager] | n/a | Available | n/a
 
 //API DESIGNER - EUROPE: EU
-| xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Planned | n/a
+| xref:design-center::design-create-publish-api-specs.adoc[API Designer] | n/a | Available | n/a
 
 //API EXPERIENCE HUB - EUROPE: EU
-| xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Planned | n/a
+| xref:api-experience-hub::index.adoc[API Experience Hub] | n/a | Available | n/a
 
 //API FUNCTIONAL MONITORING - EUROPE: EU
-| xref:api-functional-monitoring::index.adoc[API Functional Monitoring] | n/a | Planned | n/a
+| xref:api-functional-monitoring::index.adoc[API Functional Monitoring] | n/a | Available | n/a
 
 //API GOVERNANCE - EUROPE: EU
-| xref:api-governance::index.adoc[API Governance] | n/a | Planned | n/a
+| xref:api-governance::index.adoc[API Governance] | n/a | Available | n/a
 
 //API MOCKING SERVICE - EUROPE: EU
-| xref:design-center::design-mocking-service.adoc[API Mocking Service] | n/a | Planned | n/a
+| xref:design-center::design-mocking-service.adoc[API Mocking Service] | n/a | Available | n/a
 
 //CLOUDHUB - EUROPE: EU
 .2+| xref:cloudhub::index.adoc[CloudHub] | All other features | Planned .2+| n/a
 | Global CloudHub Deployment | Planned
 
 //CLOUDHUB 2.0 - EUROPE: EU
-.6+| xref:cloudhub-2::index.adoc[CloudHub 2.0] | All other features | Planned .6+a| For details, refer to:
+.6+| xref:cloudhub-2::index.adoc[CloudHub 2.0] | All other features | Available .6+a| For details, refer to:
 
 * xref:cloudhub-2::index.adoc#cloudhub2-hyperforce[CloudHub 2.0 Features by Control Plane]
 * xref:cloudhub-2::ch2-architecture.adoc#regions-and-dns-records[Runtime Plane Regions and DNS Records]
-| Deleting the Default Egress Route | Planned
-| Global Cloud Deployment | Planned
-| Private Space | Planned
-| Private Space - VPN | Planned
-| Shared Spaces | Planned
+| Deleting the Default Egress Route | Available
+| Global Cloud Deployment | Available
+| Private Space | Available
+| Private Space - VPN | Available
+| Shared Spaces | Available
 
 //CONNECTORS - EUROPE: EU
-| xref:connectors::index.adoc[Connectors] |  | Planned |
+| xref:connectors::index.adoc[Connectors] |  | Available |
 
 //DATAWEAVE - EUROPE: EU
-| xref:dataweave::index.adoc[DataWeave] | n/a | Planned | n/a
+| xref:dataweave::index.adoc[DataWeave] | n/a | Available | n/a
 
 //DATALOADER - EUROPE: EU
 | Dataloader | n/a | Not planned | https://dataloader.io/[Dataloader.io] will remain accessible globally, while its infrastructure will be hosted within the US Control Plane.
 
 //ENHANCED MULESOFT EXPERIENCE AND REMOTE MCP SERVER - EUROPE: EU
-| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Planned | n/a
+| xref:general::exp-overview.adoc[Enhanced MuleSoft Experience and Remote MCP Server] | New control plane experience for MuleSoft and the associate MCP server. | Available | n/a
 
 //OMNI GATEWAY - EUROPE: EU
-.7+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Planned .7+| n/a
-| Managed Omni Gateway on Runtime Fabric | Planned
-| Self-Managed - Connected Mode | Planned
-| Self-Managed - Local Mode | Planned
-| A2A Governance (Policies) | Available 
+.7+| xref:gateway-home::index.adoc#anypoint_flex_gateway[Omni Gateway] | Managed Omni Gateway on CloudHub 2.0 | Available .7+| n/a
+| Managed Omni Gateway on Runtime Fabric | Available
+| Self-Managed - Connected Mode | Available
+| Self-Managed - Local Mode | Available
+| A2A Governance (Policies) | Available
 | MCP Governance (Policies) | Available
 | LLM Gateway | Available
-
 
 //HYBRID STANDALONE DEPLOYMENT - EUROPE: EU
 | xref:hybrid-standalone::index.adoc[Hybrid Standalone Deployment] | n/a | Planned | n/a
 
 //IDP - EUROPE: EU
-| xref:idp::index.adoc[IDP] | n/a | Planned | n/a
+| xref:idp::index.adoc[IDP] | n/a | Available | n/a
 
 //MULE GATEWAY - EUROPE: EU
-.2+| xref:gateway-home::index.adoc#anypoint_mule_gateway[Mule Gateway] | Mule Gateway Proxies | Planned .2+| n/a
-| Mule Gateway Policies | Planned
+.2+| xref:gateway-home::index.adoc#anypoint_mule_gateway[Mule Gateway] | Mule Gateway Proxies | Available .2+| n/a
+| Mule Gateway Policies | Available
 
 //MULE RUNTIME ENGINE - EUROPE: EU
-.2+| xref:mule-runtime::index.adoc[Mule runtime engine] | All features | Planned .2+| Mule 3 is not supported as it reached EOL.
-| Diagnostics Agent | Planned
+.2+| xref:mule-runtime::index.adoc[Mule runtime engine] | All features | Available .2+| Mule 3 is not supported as it reached EOL.
+| Diagnostics Agent | Available
 
 //MUNIT - EUROPE: EU
-| xref:munit::index.adoc[MUnit] | All features | Planned | n/a
+| xref:munit::index.adoc[MUnit] | All features | Available | n/a
 
 //OBJECT STORE V2 - EUROPE: EU
-.6+| xref:object-store::index.adoc[Object Store V2] | All other features | Planned .6+a| For details, refer to:
+.6+| xref:object-store::index.adoc[Object Store V2] | All other features | Available .6+a| For details, refer to:
 
 * xref:object-store::index.adoc#os-features-control-plane[Object Store Features by Control Plane]
 * xref:object-store::osv2-faq.adoc#osv2-regions[Object Store v2 Regions]
-| Connected Apps | Planned
-| CloudHub 1.0 Deployments | Planned
+| Connected Apps | Available
+| CloudHub 1.0 Deployments | Available
 | Object Store v2 Stats API | Not planned
-| Usage Reports (Usage) | Planned
+| Usage Reports (Usage) | Available
 | Usage Charts (Access Management) | Not planned
 
 //RPA - EUROPE: EU
-| xref:rpa-home::index.adoc[RPA] | n/a | Planned | n/a
+| xref:rpa-home::index.adoc[RPA] | n/a | Available | n/a
 
 //RUNTIME FABRIC - EUROPE: EU
-| xref:runtime-fabric::index.adoc[Runtime Fabric] | n/a | Planned a| Contact your account manager to unlock this capability. For more information, refer to:
+| xref:runtime-fabric::index.adoc[Runtime Fabric] | n/a | Available a| Contact your account manager to unlock this capability. For more information, refer to:
 
 * xref:runtime-fabric::install-self-managed-network-configuration.adoc[Configuring Your Network to Support Runtime Fabric]
 * xref:runtime-fabric::configure-local-registry.adoc[Using a Local Registry with Runtime Fabric]
@@ -445,7 +444,7 @@ Europe::
 * xref:runtime-fabric::use-anypoint-monitoring.adoc[Using Anypoint Monitoring]
 
 //USAGE REPORTS - EUROPE: EU
-| xref:general::usage-reports.adoc[Usage Reports] | n/a | Planned | n/a
+| xref:general::usage-reports.adoc[Usage Reports] | n/a | Available | n/a
 |===
 --
 


### PR DESCRIPTION
## Summary
- Update US Cloud Hyperforce feature statuses from Planned to Available across the Americas features table
- Align related US Cloud rows (API Alerts, MQ Usage Metrics, and other component features) with current support

## Test plan
- [ ] Preview the Hyperforce overview Americas features table and confirm US Cloud cells show Available where updated
- [ ] Spot-check Access Management, Anypoint MQ, CloudHub 2.0, Omni Gateway, and Object Store V2 rows for correct US/Canada values