### PR TITLE
W-21429641-ch2-ps-upgrade-schedule-kt

### DIFF
--- a/cloudhub-2/modules/ROOT/pages/ch2-patch-updates.adoc
+++ b/cloudhub-2/modules/ROOT/pages/ch2-patch-updates.adoc
@@ -31,11 +31,13 @@ To prevent this kind of error, use the Recreate update strategy.
 [[self-upgrade-schedule]]
 == Schedule Infrastructure Upgrades (Optional)
 
-Schedule infrastructure upgrades earlier than the scheduled patching process, between the Release Available and the Auto-Update dates stated in the xref:release-notes::cloudhub-2/cloudhub-2-runtimes-release-notes.adoc[monthly updates table]. This way, you can choose a date in the future that better suits your organization's needs.
+Schedule infrastructure upgrades earlier than the scheduled patching process, between the Release Available date and the start of the Sandbox Environment Auto-Update window in the xref:release-notes::cloudhub-2/cloudhub-2-runtimes-release-notes.adoc[monthly updates table]. This way, you can choose a date in the future that better suits your organization's needs.
+
+After the Sandbox Environment Auto-Update window starts, you can't schedule infrastructure upgrades for sandbox or production private spaces. You can still apply an immediate upgrade. See <<opt-in-early-infrastructure-upgrades>>.
 
 On average, this upgrade takes between thirty to sixty minutes to complete. If your upgrade is queued, it can take longer than thirty minutes. The impact of the upgrade process on running applications is consistent with the auto-patching behavior described in the previous sections.
 
-You can modify or delete your scheduled upgrade if it is not already in progress, as indicated by the `Queued` status. If you cancel the schedule and do not create another or opt in to an earlier upgrade, the upgrade occurs during the mandatory patching window.
+You can modify or delete your scheduled upgrade if it isn't already in progress, as indicated by the `Queued` status. If you cancel the schedule and don't create another or opt in to an earlier upgrade, the upgrade occurs during the mandatory patching window.
 
 === Schedule the Upgrade via Runtime Manager
 
@@ -50,9 +52,12 @@ Upgrades occur at 00:00 in your local timezone on the date you select.
 
 After applying the upgrade, you can check the status under the *Infra Status* column.
 
+[[opt-in-early-infrastructure-upgrades]]
 == Opt-in Early Infrastructure Upgrades (Optional)
 
-Opt in to apply infrastructure upgrades earlier than the scheduled patching process, between the Release Available and the Auto-Update dates stated in the xref:release-notes::cloudhub-2/cloudhub-2-runtimes-release-notes.adoc[monthly updates table]. This way, you can choose the time that better suits your organization's needs.
+Opt in to apply an infrastructure upgrade immediately, earlier than the scheduled patching process. You can opt in between the Release Available date and the mandatory Auto-Update for that private space, as stated in the xref:release-notes::cloudhub-2/cloudhub-2-runtimes-release-notes.adoc[monthly updates table]. This way, you can choose the time that better suits your organization's needs.
+
+After the Sandbox Environment Auto-Update window starts, you can't schedule an upgrade for sandbox or production private spaces, but you can still select *Upgrade now* to apply an immediate upgrade.
 
 On average, this upgrade takes between thirty to sixty minutes to complete. If your upgrade is queued, it can take longer than thirty minutes. The impact of the upgrade process on running applications is consistent with the auto-patching behavior described in the previous sections.
 


### PR DESCRIPTION
## Summary
- Clarify that Private Space infrastructure upgrade **scheduling** is available only until the **Sandbox Environment Auto-Update** window starts (not until each environment's own Auto-Update date)
- After that window starts, scheduling is blocked for **sandbox and production** private spaces
- Note that **Upgrade now** (opt-in) remains available for an immediate upgrade
- Update both *Schedule Infrastructure Upgrades* and *Opt-in Early Infrastructure Upgrades* on `ch2-patch-updates.adoc`

## GUS
- Doc request: [W-21429641](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Vg0iYYAR/view)
- Investigation: [W-21050646](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Tco1xYAB/view)

## Sources
- GUS W-21429641 — doc clarification request
- GUS W-21050646 — closing summary and Chatter (Andrew Huynh / Taka Ito): scheduling blocked for both env types at sandbox window; on-demand still allowed
- Slack [#ch2-docs](https://salesforce-internal.slack.com/archives/C0264EX4VD0/p1771863704980639) — Ankur Sethi: expected behavior is to block self-patching once Sandbox update dates start

## Test plan
- [ ] Preview `ch2-patch-updates.adoc` Schedule and Opt-in sections
- [ ] Confirm xref to monthly updates table and in-page `<<opt-in-early-infrastructure-upgrades>>` resolve
- [ ] Confirm wording doesn't imply production PS can still be scheduled after sandbox Auto-Update starts